### PR TITLE
use namespaces

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -264,7 +264,7 @@ int Benchmark<T>::check_params()
         }
     }
 
-    size_t wordsize_limit = nttec::arith::_log2<T>(n) + 1;
+    size_t wordsize_limit = nttec::arith::log2<T>(n) + 1;
     if (wordsize_limit > 8 * word_size) {
         return ERR_COMPT_CODE_LEN_T;
     }

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -124,31 +124,33 @@ int Benchmark<T>::init()
 {
     switch (fec_type) {
     case EC_TYPE_GF2NRSV:
-        fec = new FECGF2NRS<T>(word_size, k, m, FECGF2NRS<T>::VANDERMONDE);
+        fec = new nttec::fec::FECGF2NRS<T>(
+            word_size, k, m, nttec::fec::FECGF2NRS<T>::VANDERMONDE);
         break;
     case EC_TYPE_GF2NRSC:
-        fec = new FECGF2NRS<T>(word_size, k, m, FECGF2NRS<T>::CAUCHY);
+        fec = new nttec::fec::FECGF2NRS<T>(
+            word_size, k, m, nttec::fec::FECGF2NRS<T>::CAUCHY);
         break;
     case EC_TYPE_GF2NFFTRS:
-        fec = new FECGF2NFFTRS<T>(word_size, k, m);
+        fec = new nttec::fec::FECGF2NFFTRS<T>(word_size, k, m);
         break;
     case EC_TYPE_GF2NFFTADDRS:
-        fec = new FECGF2NFFTADDRS<T>(word_size, k, m);
+        fec = new nttec::fec::FECGF2NFFTADDRS<T>(word_size, k, m);
         break;
     case EC_TYPE_GFPFFTRS:
-        fec = new FECGFPFFTRS<T>(word_size, k, m);
+        fec = new nttec::fec::FECGFPFFTRS<T>(word_size, k, m);
         break;
     case EC_TYPE_NGFF4RS:
-        fec = new FECNGFF4RS<T>(word_size, k, m);
+        fec = new nttec::fec::FECNGFF4RS<T>(word_size, k, m);
         break;
     case EC_TYPE_FNTRS:
-        fec = new FECFNTRS<T>(word_size, k, m, pkt_size);
+        fec = new nttec::fec::FECFNTRS<T>(word_size, k, m, pkt_size);
         break;
     default:
         return ERR_FEC_TYPE_NOT_SUPPORTED;
     }
 
-    this->systematic_ec = (fec->type == FEC<T>::TYPE_1);
+    this->systematic_ec = (fec->type == nttec::fec::FEC<T>::TYPE_1);
     if (this->systematic_ec) {
         this->n_c = this->m;
     }
@@ -196,7 +198,7 @@ int Benchmark<T>::init()
     c_streams = new std::vector<std::ostream*>(n_c);
     a_streams = new std::vector<std::istream*>(n);
     r_streams = new std::vector<std::ostream*>(k);
-    c_propos = new std::vector<KeyValue*>(n_c);
+    c_propos = new std::vector<nttec::KeyValue*>(n_c);
 
     for (i = 0; i < k; i++) {
         d_streams->at(i) = new std::istream(d_istreambufs->at(i));
@@ -204,7 +206,7 @@ int Benchmark<T>::init()
 
     for (i = 0; i < n_c; i++) {
         c_streams->at(i) = new std::ostream(c_ostreambufs->at(i));
-        c_propos->at(i) = new KeyValue();
+        c_propos->at(i) = new nttec::KeyValue();
     }
 
     if (systematic_ec) {
@@ -262,7 +264,7 @@ int Benchmark<T>::check_params()
         }
     }
 
-    size_t wordsize_limit = _log2<T>(n) + 1;
+    size_t wordsize_limit = nttec::arith::_log2<T>(n) + 1;
     if (wordsize_limit > 8 * word_size) {
         return ERR_COMPT_CODE_LEN_T;
     }
@@ -390,7 +392,7 @@ template <typename T>
 void Benchmark<T>::get_avail_chunks(
     std::vector<std::istream*>* avail_d_chunks,
     std::vector<std::istream*>* avail_c_chunks,
-    std::vector<KeyValue*>* avail_c_props)
+    std::vector<nttec::KeyValue*>* avail_c_props)
 {
     std::random_shuffle(c_chunks_id->begin(), c_chunks_id->end());
 
@@ -451,7 +453,7 @@ bool Benchmark<T>::decode()
 {
     std::vector<std::istream*> d_streams_shuffled(k, nullptr);
     std::vector<std::istream*> c_streams_shuffled(n_c, nullptr);
-    std::vector<KeyValue*> c_props_shuffled(n_c, nullptr);
+    std::vector<nttec::KeyValue*> c_props_shuffled(n_c, nullptr);
 
     get_avail_chunks(
         &d_streams_shuffled, &c_streams_shuffled, &c_props_shuffled);

--- a/benchmark/benchmark.h
+++ b/benchmark/benchmark.h
@@ -13,30 +13,6 @@
 #include "prng.h"
 #include "stats.h"
 
-template class FECGF2NRS<uint32_t>;
-template class FECGF2NRS<uint64_t>;
-template class FECGF2NRS<__uint128_t>;
-
-template class FECGF2NFFTRS<uint32_t>;
-template class FECGF2NFFTRS<uint64_t>;
-template class FECGF2NFFTRS<__uint128_t>;
-
-template class FECGF2NFFTADDRS<uint32_t>;
-template class FECGF2NFFTADDRS<uint64_t>;
-template class FECGF2NFFTADDRS<__uint128_t>;
-
-template class FECGFPFFTRS<uint32_t>;
-template class FECGFPFFTRS<uint64_t>;
-template class FECGFPFFTRS<__uint128_t>;
-
-template class FECFNTRS<uint32_t>;
-template class FECFNTRS<uint64_t>;
-template class FECFNTRS<__uint128_t>;
-
-template class FECNGFF4RS<uint32_t>;
-template class FECNGFF4RS<uint64_t>;
-template class FECNGFF4RS<__uint128_t>;
-
 enum ec_type {
     EC_TYPE_ALL = 0,
     EC_TYPE_FNTRS,
@@ -274,7 +250,7 @@ class Benchmark {
     size_t chunk_size;
     uint32_t samples_nb;
     PRNG* prng = nullptr;
-    FEC<T>* fec = nullptr;
+    nttec::fec::FEC<T>* fec = nullptr;
     Params_t* params = nullptr;
 
     bool systematic_ec = false;
@@ -302,7 +278,7 @@ class Benchmark {
     // streams of repair chunks
     std::vector<std::ostream*>* r_streams = nullptr;
     // propos vector
-    std::vector<KeyValue*>* c_propos = nullptr;
+    std::vector<nttec::KeyValue*>* c_propos = nullptr;
 
     int init();
     int check_params();
@@ -318,7 +294,7 @@ class Benchmark {
     void get_avail_chunks(
         std::vector<std::istream*>* avail_d_chunks,
         std::vector<std::istream*>* avail_c_chunks,
-        std::vector<KeyValue*>* avail_c_props);
+        std::vector<nttec::KeyValue*>* avail_c_props);
     bool encode();
     bool decode();
     void show(Stats_t* stats);

--- a/src/arith.h
+++ b/src/arith.h
@@ -21,63 +21,63 @@ using SignedDoubleT = typename SignedDouble<T>::T;
 namespace arith {
 
 template <class T>
-T _sqrt(T n);
+T sqrt(T n);
 template <class T>
-T _exp(T base, T exponent);
+T exp(T base, T exponent);
 template <class T>
-T _exp_mod(T base, T exponent, T modulus);
+T exp_mod(T base, T exponent, T modulus);
 template <class T>
-bool _is_power_of_2(int x);
+bool is_power_of_2(int x);
 template <class T>
-T _get_smallest_power_of_2(int x);
+T get_smallest_power_of_2(int x);
 template <class T>
-int _log2(int x);
+int log2(int x);
 template <class T>
-int _exp2(int x);
+int exp2(int x);
 template <class T>
-SignedDoubleT<T> _extended_gcd(
+SignedDoubleT<T> extended_gcd(
     SignedDoubleT<T> a,
     SignedDoubleT<T> b,
     SignedDoubleT<T> bezout_coef[2],
     SignedDoubleT<T> quotient_gcd[2]);
 template <class T>
-T _chinese_remainder(int n_mod, T a[], T n[]);
+T chinese_remainder(int n_mod, T a[], T n[]);
 template <class T>
-int _jacobi(SignedDoubleT<T> n, SignedDoubleT<T> m);
+int jacobi(SignedDoubleT<T> n, SignedDoubleT<T> m);
 template <class T>
-bool _solovay_strassen1(T a, T n);
+bool solovay_strassen1(T a, T n);
 template <class T>
-bool _solovay_strassen(T n);
+bool solovay_strassen(T n);
 template <class T>
-bool _is_prime(T n);
+bool is_prime(T n);
 template <class T>
-T _weak_rand(T max);
+T weak_rand(T max);
 template <class T>
-T _weak_rand0(T max);
+T weak_rand0(T max);
 template <class T>
-T _gcd(T u, T v);
+T gcd(T u, T v);
 template <class T>
-void _factor_distinct_prime(T n, std::vector<T>* output);
+void factor_distinct_prime(T n, std::vector<T>* output);
 template <class T>
-void _factor_prime(T nb, std::vector<T>* primes, std::vector<int>* exponent);
+void factor_prime(T nb, std::vector<T>* primes, std::vector<int>* exponent);
 template <class T>
-void _get_proper_divisors(T n, std::vector<T>* output);
+void get_proper_divisors(T n, std::vector<T>* output);
 template <class T>
-void _get_proper_divisors(T n, std::vector<T>* primes, std::vector<T>* output);
+void get_proper_divisors(T n, std::vector<T>* primes, std::vector<T>* output);
 template <class T>
-void _compute_all_divisors(T nb, std::vector<T>* output);
+void compute_all_divisors(T nb, std::vector<T>* output);
 template <class T>
-T _get_code_len(T order, T n);
+T get_code_len(T order, T n);
 template <class T>
-T _get_code_len_high_compo(T order, T n);
+T get_code_len_high_compo(T order, T n);
 template <class T>
-T _get_code_len_high_compo(std::vector<T>* factors, T n);
+T get_code_len_high_compo(std::vector<T>* factors, T n);
 template <class T>
-void _get_coprime_factors(T nb, std::vector<T>* output);
+void get_coprime_factors(T nb, std::vector<T>* output);
 template <class T>
-void _get_prime_factors(T nb, std::vector<T>* output);
+void get_prime_factors(T nb, std::vector<T>* output);
 template <class T>
-void _get_prime_factors_final(
+void get_prime_factors_final(
     std::vector<T>* primes,
     std::vector<int>* exponent,
     std::vector<T>* output);
@@ -90,7 +90,7 @@ void _get_prime_factors_final(
  * @return
  */
 template <class T>
-T _sqrt(T remainder)
+T sqrt(T remainder)
 {
     // calculated by precompiler = same runtime as: place = 0x40000000
     T place = (T)1 << (sizeof(T) * 8 - 2);
@@ -121,7 +121,7 @@ T _sqrt(T remainder)
  * @return
  */
 template <class T>
-T _exp(T base, T exponent)
+T exp(T base, T exponent)
 {
     if (exponent == 0)
         return 1;
@@ -149,7 +149,7 @@ T _exp(T base, T exponent)
  * @return
  */
 template <class T>
-T _exp_mod(T base, T exponent, T modulus)
+T exp_mod(T base, T exponent, T modulus)
 {
     if (1 == modulus)
         return 0;
@@ -174,7 +174,7 @@ T _exp_mod(T base, T exponent, T modulus)
  * @return
  */
 template <class T>
-bool _is_power_of_2(int x)
+bool is_power_of_2(int x)
 {
     return x > 0 && !(x & (x - 1));
 }
@@ -187,11 +187,11 @@ bool _is_power_of_2(int x)
  * @return
  */
 template <class T>
-T _get_smallest_power_of_2(int x)
+T get_smallest_power_of_2(int x)
 {
-    if (_is_power_of_2<T>(x))
+    if (is_power_of_2<T>(x))
         return x;
-    return _exp2<T>(_log2<T>(x) + 1);
+    return exp2<T>(log2<T>(x) + 1);
 }
 
 /**
@@ -202,7 +202,7 @@ T _get_smallest_power_of_2(int x)
  * @return
  */
 template <class T>
-int _log2(int x)
+int log2(int x)
 {
     int result = 0;
 
@@ -228,7 +228,7 @@ int _log2(int x)
  * @return
  */
 template <class T>
-int _exp2(int x)
+int exp2(int x)
 {
     return 1 << x;
 }
@@ -250,7 +250,7 @@ int _exp2(int x)
  * @return the GCD
  */
 template <class T>
-SignedDoubleT<T> _extended_gcd(
+SignedDoubleT<T> extended_gcd(
     SignedDoubleT<T> a,
     SignedDoubleT<T> b,
     SignedDoubleT<T> bezout_coef[2],
@@ -294,49 +294,53 @@ SignedDoubleT<T> _extended_gcd(
     return old_r;
 }
 
-/**
- * Chinese remainder theorem (from Wikipedia)
+/** Apply the Chinese remainder theorem.
+ *
+ * Implementation from Wikipedia.
  *
  * @param n_mod number of moduli
  * @param a the a's (integers)
  * @param n the n's (moduli)
  *
- * XXX check if there is a solution
+ * @todo Check if there is a solution.
  *
- * @return the solution
+ * @return the solution.
  * @throw NTTEC_EX_NO_SOLUTION
  */
 template <class T>
-T _chinese_remainder(int n_mod, T a[], T n[])
+T chinese_remainder(int n_mod, T a[], T n[])
 {
-    int i;
-    SignedDoubleT<T> _N, x;
+    SignedDoubleT<T> acc;
+    SignedDoubleT<T> x;
     SignedDoubleT<T>* N = new SignedDoubleT<T>[n_mod];
     SignedDoubleT<T>* M = new SignedDoubleT<T>[n_mod];
 
-    _N = 1;
-    for (i = 0; i < n_mod; i++)
-        _N *= n[i];
+    acc = 1;
+    for (int i = 0; i < n_mod; i++) {
+        acc *= n[i];
+    }
 
-    for (i = 0; i < n_mod; i++) {
+    for (int i = 0; i < n_mod; i++) {
         SignedDoubleT<T> bezout[2];
 
-        N[i] = _N / n[i];
-        _extended_gcd<T>(N[i], n[i], bezout, nullptr);
+        N[i] = acc / n[i];
+        extended_gcd<T>(N[i], n[i], bezout, nullptr);
         M[i] = bezout[0]; // XXX % n[i];
     }
 
     x = 0;
-    for (i = 0; i < n_mod; i++)
+    for (int i = 0; i < n_mod; i++) {
         x += N[i] * M[i] * a[i];
+    }
 
     delete[] N;
     delete[] M;
 
-    x = x % _N;
+    x = x % acc;
 
-    if (x < 0)
-        x = _N + x;
+    if (x < 0) {
+        x = acc + x;
+    }
 
     return x;
 }
@@ -357,7 +361,7 @@ T _chinese_remainder(int n_mod, T a[], T n[])
  * @throw NT_EX_INVAL if b is even or b is negative
  */
 template <class T>
-int _jacobi(SignedDoubleT<T> n, SignedDoubleT<T> m)
+int jacobi(SignedDoubleT<T> n, SignedDoubleT<T> m)
 {
     SignedDoubleT<T> t;
     int jac;
@@ -409,28 +413,27 @@ int _jacobi(SignedDoubleT<T> n, SignedDoubleT<T> m)
 }
 
 template <class T>
-bool _solovay_strassen1(T a, T n)
+bool solovay_strassen1(T a, T n)
 {
-    T _n = (n - 1) / 2;
-    T _j = exp_mod(a, _n, n);
+    const T exponent = (n - 1) / 2;
+    const T res = exp_mod(a, exponent, n);
     int j = jacobi(a, n);
-    if (j < 0)
-        _j = _j - n;
-    return j == _j;
+    if (j < 0) {
+        res = res - n;
+    }
+    return j == res;
 }
 
-/**
- * Perform the Solvay-Strassen primality test
+/** Perform the Solovay–Strassen primality test.
  *
- * @param n check if n is prime
- *
- * @return true if n is (probably) prime else false
+ * @param n check if `n` is prime
+ * @return true if `n` is (probably) prime else false.
  */
 template <class T>
-bool _solovay_strassen(T n)
+bool solovay_strassen(T n)
 {
     for (int i = 0; i < 100; i++) {
-        T a = _weak_rand<T>(n);
+        T a = weak_rand<T>(n);
         if (!solovay_strassen1(a, n))
             return false;
     }
@@ -445,12 +448,12 @@ bool _solovay_strassen(T n)
  * @return
  */
 template <class T>
-bool _is_prime(T n)
+bool is_prime(T n)
 {
     if (n == 2)
         return true;
 
-    T root = _sqrt<T>(n);
+    T root = sqrt<T>(n);
     for (T i = 2; i <= root; i++) {
         if (n % i == 0)
             return false;
@@ -466,7 +469,7 @@ bool _is_prime(T n)
  * @return
  */
 template <class T>
-T _weak_rand(T max)
+T weak_rand(T max)
 {
     T r;
 retry:
@@ -484,7 +487,7 @@ retry:
  * @return
  */
 template <class T>
-T _weak_rand0(T max)
+T weak_rand0(T max)
 {
     T r;
     r = rand() % max;
@@ -496,7 +499,7 @@ T _weak_rand0(T max)
  *  exponent is ignored.
  */
 template <class T>
-void _factor_distinct_prime(T nb, std::vector<T>* output)
+void factor_distinct_prime(T nb, std::vector<T>* output)
 {
     T last_found = 1;
     while (nb % 2 == 0) {
@@ -507,7 +510,7 @@ void _factor_distinct_prime(T nb, std::vector<T>* output)
         nb = nb / 2;
     }
     // n must be odd at this point.  So we can skip one element
-    for (T i = 3; i <= _sqrt<T>(nb); i = i + 2) {
+    for (T i = 3; i <= sqrt<T>(nb); i = i + 2) {
         // While i divides n, get i and divide n
         while (nb % i == 0) {
             if (last_found != i) {
@@ -528,11 +531,11 @@ void _factor_distinct_prime(T nb, std::vector<T>* output)
  * Get proper divisors of a given number from its factored distince primes
  */
 template <class T>
-void _get_proper_divisors(T nb, std::vector<T>* output)
+void get_proper_divisors(T nb, std::vector<T>* output)
 {
     std::vector<T> input;
     typename std::vector<T>::iterator it;
-    _factor_distinct_prime<T>(nb, &input);
+    factor_distinct_prime<T>(nb, &input);
     // std::cout << "nb: " << nb << std::endl;
     for (it = input.begin(); it != input.end(); ++it) {
         if (*it < nb) {
@@ -546,7 +549,7 @@ void _get_proper_divisors(T nb, std::vector<T>* output)
  * Get proper divisors of a given number from its factored distince primes
  */
 template <class T>
-void _get_proper_divisors(T nb, std::vector<T>* primes, std::vector<T>* output)
+void get_proper_divisors(T nb, std::vector<T>* primes, std::vector<T>* output)
 {
     assert(primes != nullptr);
     typename std::vector<T>::iterator it;
@@ -563,7 +566,7 @@ void _get_proper_divisors(T nb, std::vector<T>* primes, std::vector<T>* output)
  * A given number `n` is factored into primes
  */
 template <class T>
-void _factor_prime(T nb, std::vector<T>* primes, std::vector<int>* exponent)
+void factor_prime(T nb, std::vector<T>* primes, std::vector<int>* exponent)
 {
     // std::cout << nb << ": ";
     int occurence = 0;
@@ -579,7 +582,7 @@ void _factor_prime(T nb, std::vector<T>* primes, std::vector<int>* exponent)
         occurence = 0;
     }
     // n must be odd at this point.  So we can skip one element
-    for (T i = 3; i <= _sqrt<T>(nb); i = i + 2) {
+    for (T i = 3; i <= sqrt<T>(nb); i = i + 2) {
         // While i divides n, get i and divide n
         while (nb % i == 0) {
             occurence++;
@@ -614,7 +617,7 @@ void _factor_prime(T nb, std::vector<T>* primes, std::vector<int>* exponent)
  * @return the GCD(u, v)
  */
 template <class T>
-T _gcd(T u, T v)
+T gcd(T u, T v)
 {
     T r;
     if (v == 0)
@@ -635,11 +638,11 @@ T _gcd(T u, T v)
  *
  */
 template <class T>
-void _compute_all_divisors(T nb, std::vector<T>* output)
+void compute_all_divisors(T nb, std::vector<T>* output)
 {
     typename std::vector<T> tmp;
 
-    T nb_sqrt = _sqrt<T>(nb);
+    T nb_sqrt = sqrt<T>(nb);
     for (T i = 1; i <= nb_sqrt; i++) {
         // While i divides n, get i and n/i
         if (nb % i == 0) {
@@ -662,13 +665,13 @@ void _compute_all_divisors(T nb, std::vector<T>* output)
  * @return root
  */
 template <class T>
-T _get_code_len(T order, T n)
+T get_code_len(T order, T n)
 {
     if (order % n == 0)
         return n;
     if (order < n)
         assert(false);
-    T nb_sqrt = _sqrt<T>(order);
+    T nb_sqrt = sqrt<T>(order);
     T i;
     if (n > nb_sqrt) {
         for (i = order / n; i >= 1; i--) {
@@ -699,13 +702,13 @@ T _get_code_len(T order, T n)
  * @return root
  */
 template <class T>
-T _get_code_len_high_compo(T order, T n)
+T get_code_len_high_compo(T order, T n)
 {
     if (order < n)
         assert(false);
 
     std::vector<T> factors;
-    _get_prime_factors<T>(order, &factors);
+    get_prime_factors<T>(order, &factors);
     T x = 1;
     typename std::vector<T>::size_type i, j;
     // forward to get a divisor of (q-1) >= n and of highly composited
@@ -737,7 +740,7 @@ T _get_code_len_high_compo(T order, T n)
  * @return code length
  */
 template <class T>
-T _get_code_len_high_compo(std::vector<T>* factors, T n)
+T get_code_len_high_compo(std::vector<T>* factors, T n)
 {
     assert(factors != nullptr);
 
@@ -767,15 +770,15 @@ T _get_code_len_high_compo(std::vector<T>* factors, T n)
  * @return
  */
 template <class T>
-void _get_coprime_factors(T nb, std::vector<T>* output)
+void get_coprime_factors(T nb, std::vector<T>* output)
 {
     std::vector<T> primes;
     std::vector<int> exponent;
-    _factor_prime<T>(nb, &primes, &exponent);
+    factor_prime<T>(nb, &primes, &exponent);
 
     typename std::vector<T>::size_type i;
     for (i = 0; i != primes.size(); ++i) {
-        output->push_back(_exp<T>(primes[i], exponent[i]));
+        output->push_back(exp<T>(primes[i], exponent[i]));
     }
 }
 
@@ -787,12 +790,12 @@ void _get_coprime_factors(T nb, std::vector<T>* output)
  * @return
  */
 template <class T>
-void _get_prime_factors(T nb, std::vector<T>* output)
+void get_prime_factors(T nb, std::vector<T>* output)
 {
     std::vector<T> primes;
     std::vector<int> exponent;
-    _factor_prime<T>(nb, &primes, &exponent);
-    _get_prime_factors_final<T>(&primes, &exponent, output);
+    factor_prime<T>(nb, &primes, &exponent);
+    get_prime_factors_final<T>(&primes, &exponent, output);
 }
 
 /**
@@ -801,10 +804,9 @@ void _get_prime_factors(T nb, std::vector<T>* output)
  * @param primes - vector of primes
  * @param primes - vector of exponents each for prime
  * @param output - vector of co-prime divisors of nb
- * @return
  */
 template <class T>
-void _get_prime_factors_final(
+void get_prime_factors_final(
     std::vector<T>* primes,
     std::vector<int>* exponent,
     std::vector<T>* output)

--- a/src/arith.h
+++ b/src/arith.h
@@ -9,11 +9,16 @@
 #include "big_int.h"
 #include "core.h"
 
+namespace nttec {
+
 template <typename T>
 using DoubleT = typename Double<T>::T;
 
 template <typename T>
 using SignedDoubleT = typename SignedDouble<T>::T;
+
+/** Base/core arithmetical functions of NTTEC. */
+namespace arith {
 
 template <class T>
 T _sqrt(T n);
@@ -810,5 +815,8 @@ void _get_prime_factors_final(
             output->push_back(primes->at(i));
         }
 }
+
+} // namespace arith
+} // namespace nttec
 
 #endif

--- a/src/big_int.h
+++ b/src/big_int.h
@@ -4,8 +4,14 @@
 
 #include <iostream>
 
+namespace std {
+
 std::ostream& operator<<(std::ostream& dest, __uint128_t value);
 std::ostream& operator<<(std::ostream& dest, __int128_t value);
+
+} // namespace std
+
+namespace nttec {
 
 struct uint256_t {
     __uint128_t lo;
@@ -74,5 +80,7 @@ struct int256_t {
         return lo;
     }
 };
+
+} // namespace nttec
 
 #endif

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2,6 +2,8 @@
 
 #include "config.h"
 
+namespace nttec {
+
 std::istream& operator>>(std::istream& ins, KeyValue& d)
 {
     std::string s, key, value;
@@ -49,3 +51,5 @@ std::ostream& operator<<(std::ostream& outs, const KeyValue& d)
         outs << iter->first << " = " << iter->second << std::endl;
     return outs;
 }
+
+} // namespace nttec

--- a/src/config.h
+++ b/src/config.h
@@ -6,6 +6,8 @@
 #include <map>
 #include <string>
 
+namespace nttec {
+
 struct KeyValue : std::map<std::string, std::string> {
     bool is_key(const std::string& s) const
     {
@@ -15,5 +17,7 @@ struct KeyValue : std::map<std::string, std::string> {
 
 std::istream& operator>>(std::istream& ins, KeyValue& d);
 std::ostream& operator<<(std::ostream& outs, const KeyValue& d);
+
+} // namespace nttec
 
 #endif

--- a/src/core.h
+++ b/src/core.h
@@ -7,6 +7,8 @@
 
 #include "big_int.h"
 
+namespace nttec {
+
 template <typename Type>
 struct Double {
 };
@@ -61,5 +63,7 @@ typedef enum {
     NTTEC_EX_IO,
     NTTEC_EX_DIV_BY_ZERO,
 } NttecException;
+
+} // namespace nttec
 
 #endif

--- a/src/dft.h
+++ b/src/dft.h
@@ -5,6 +5,11 @@
 #include "gf.h"
 #include "vec.h"
 
+namespace nttec {
+
+/** Various Fast Fourier Transform implementations. */
+namespace fft {
+
 /*
  * DFT over the field gf and over vectors of size n with w as n-th
  * root of unity
@@ -12,29 +17,29 @@
 template <typename T>
 class DFT {
   protected:
-    GF<T>* gf;
+    gf::GF<T>* gf;
     int n;
     T inv_n_mod_p;
-    Vec<T>* vec_inv_n = nullptr;
-    DFT(GF<T>* gf, int n);
+    vec::Vec<T>* vec_inv_n = nullptr;
+    DFT(gf::GF<T>* gf, int n);
 
   public:
     virtual ~DFT();
     int get_n();
-    GF<T>* get_gf();
-    virtual void fft(Vec<T>* output, Vec<T>* input) = 0;
-    virtual void ifft(Vec<T>* output, Vec<T>* input) = 0;
-    virtual void fft_inv(Vec<T>* output, Vec<T>* input) = 0;
+    gf::GF<T>* get_gf();
+    virtual void fft(vec::Vec<T>* output, vec::Vec<T>* input) = 0;
+    virtual void ifft(vec::Vec<T>* output, vec::Vec<T>* input) = 0;
+    virtual void fft_inv(vec::Vec<T>* output, vec::Vec<T>* input) = 0;
 };
 
 template <typename T>
-DFT<T>::DFT(GF<T>* gf, int n)
+DFT<T>::DFT(gf::GF<T>* gf, int n)
 {
     this->gf = gf;
     this->n = n;
     this->inv_n_mod_p = gf->inv(n) % gf->get_sub_field()->card();
 
-    this->vec_inv_n = new Vec<T>(this->gf, n);
+    this->vec_inv_n = new vec::Vec<T>(this->gf, n);
     for (int i = 0; i < n; i++) {
         this->vec_inv_n->set(i, this->inv_n_mod_p);
     }
@@ -54,9 +59,12 @@ int DFT<T>::get_n()
 }
 
 template <typename T>
-GF<T>* DFT<T>::get_gf()
+gf::GF<T>* DFT<T>::get_gf()
 {
     return gf;
 }
+
+} // namespace fft
+} // namespace nttec
 
 #endif

--- a/src/dftn.h
+++ b/src/dftn.h
@@ -5,6 +5,9 @@
 #include "dft.h"
 #include "mat.h"
 
+namespace nttec {
+namespace fft {
+
 /**
  * Algorithm for very small n
  */
@@ -16,18 +19,18 @@ class DFTN : public DFT<T> {
     Mat<T>* W;
     Mat<T>* inv_W;
     void compute_W(Mat<T>* _W, T _w);
-    void _fft(Vec<T>* output, Vec<T>* input, Mat<T>* _W);
+    void _fft(vec::Vec<T>* output, vec::Vec<T>* input, Mat<T>* _W);
 
   public:
-    DFTN(GF<T>* gf, int n, T w);
+    DFTN(gf::GF<T>* gf, int n, T w);
     ~DFTN();
-    void fft(Vec<T>* output, Vec<T>* input);
-    void ifft(Vec<T>* output, Vec<T>* input);
-    void fft_inv(Vec<T>* output, Vec<T>* input);
+    void fft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void ifft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void fft_inv(vec::Vec<T>* output, vec::Vec<T>* input);
 };
 
 template <typename T>
-DFTN<T>::DFTN(GF<T>* gf, int n, T w) : DFT<T>(gf, n)
+DFTN<T>::DFTN(gf::GF<T>* gf, int n, T w) : DFT<T>(gf, n)
 {
     this->w = w;
     this->inv_w = gf->inv(w);
@@ -63,13 +66,13 @@ void DFTN<T>::compute_W(Mat<T>* _W, T _w)
 }
 
 template <typename T>
-void DFTN<T>::_fft(Vec<T>* output, Vec<T>* input, Mat<T>* _W)
+void DFTN<T>::_fft(vec::Vec<T>* output, vec::Vec<T>* input, Mat<T>* _W)
 {
     _W->mul(output, input);
 }
 
 template <typename T>
-void DFTN<T>::fft(Vec<T>* output, Vec<T>* input)
+void DFTN<T>::fft(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     _fft(output, input, W);
 }
@@ -80,17 +83,20 @@ void DFTN<T>::fft(Vec<T>* output, Vec<T>* input)
  *
  */
 template <typename T>
-void DFTN<T>::fft_inv(Vec<T>* output, Vec<T>* input)
+void DFTN<T>::fft_inv(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     _fft(output, input, inv_W);
 }
 
 template <typename T>
-void DFTN<T>::ifft(Vec<T>* output, Vec<T>* input)
+void DFTN<T>::ifft(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     _fft(output, input, inv_W);
     if (this->inv_n_mod_p > 1)
         output->mul_scalar(this->inv_n_mod_p);
 }
+
+} // namespace fft
+} // namespace nttec
 
 #endif

--- a/src/fecfntrs.h
+++ b/src/fecfntrs.h
@@ -38,7 +38,7 @@ class FECFNTRS : public FEC<T> {
         this->gf = new gf::GFP<T>(gf_p);
 
         assert(
-            arith::_jacobi<T>(this->gf->get_prime_root(), this->gf->card())
+            arith::jacobi<T>(this->gf->get_prime_root(), this->gf->card())
             == -1);
 
         // with this encoder we cannot exactly satisfy users request, we need to

--- a/src/fecfntrs.h
+++ b/src/fecfntrs.h
@@ -8,6 +8,9 @@
 #include "vvec.h"
 #include "vvecp.h"
 
+namespace nttec {
+namespace fec {
+
 /**
  * GF_2^2^k+1 based RS (Fermat Number Transform)
  * As suggested by the paper:
@@ -17,7 +20,7 @@
 template <typename T>
 class FECFNTRS : public FEC<T> {
   private:
-    FFT2K<T>* fft = nullptr;
+    fft::FFT2K<T>* fft = nullptr;
 
   public:
     T n;
@@ -32,9 +35,11 @@ class FECFNTRS : public FEC<T> {
         assert(word_size < 4);
         // warning all fermat numbers >= to F_5 (2^32+1) are composite!!!
         T gf_p = (1ULL << (8 * word_size)) + 1;
-        this->gf = new GFP<T>(gf_p);
+        this->gf = new gf::GFP<T>(gf_p);
 
-        assert(_jacobi<T>(this->gf->get_prime_root(), this->gf->card()) == -1);
+        assert(
+            arith::_jacobi<T>(this->gf->get_prime_root(), this->gf->card())
+            == -1);
 
         // with this encoder we cannot exactly satisfy users request, we need to
         // pad n = minimal divisor of (q-1) that is at least (n_parities +
@@ -47,7 +52,7 @@ class FECFNTRS : public FEC<T> {
         // std::cerr << "n=" << n << "\n";
         // std::cerr << "r=" << r << "\n";
 
-        this->fft = new FFT2K<T>(this->gf, n, pkt_size);
+        this->fft = new fft::FFT2K<T>(this->gf, n, pkt_size);
     }
 
     ~FECFNTRS()
@@ -70,12 +75,12 @@ class FECFNTRS : public FEC<T> {
      * @param words must be n_data
      */
     void encode(
-        Vec<T>* output,
+        vec::Vec<T>* output,
         std::vector<KeyValue*> props,
         off_t offset,
-        Vec<T>* words)
+        vec::Vec<T>* words)
     {
-        VVec<T> vwords(words, n);
+        vec::VVec<T> vwords(words, n);
         fft->fft(output, &vwords);
         // max_value = 2^x
         T thres = fft->get_gf()->card() - 1;
@@ -92,12 +97,12 @@ class FECFNTRS : public FEC<T> {
     }
 
     void encode(
-        Vecp<T>* output,
+        vec::Vecp<T>* output,
         std::vector<KeyValue*> props,
         off_t offset,
-        Vecp<T>* words)
+        vec::Vecp<T>* words)
     {
-        VVecp<T> vwords(words, n);
+        vec::VVecp<T> vwords(words, n);
         fft->fft(output, &vwords);
         // check for out of range value in output
         int size = output->get_size();
@@ -150,15 +155,15 @@ class FECFNTRS : public FEC<T> {
      * @param words v=(v_0, v_1, ..., v_k-1) k must be exactly n_data
      */
     void decode(
-        Vec<T>* output,
+        vec::Vec<T>* output,
         std::vector<KeyValue*> props,
         off_t offset,
-        Vec<T>* fragments_ids,
-        Vec<T>* words)
+        vec::Vec<T>* fragments_ids,
+        vec::Vec<T>* words)
     {
         int k = this->n_data; // number of fragments received
         // vector x=(x_0, x_1, ..., x_k-1)
-        Vec<T> vx(this->gf, k);
+        vec::Vec<T> vx(this->gf, k);
         for (int i = 0; i < k; i++) {
             vx.set(i, this->gf->exp(r, fragments_ids->get(i)));
         }
@@ -193,7 +198,7 @@ class FECFNTRS : public FEC<T> {
         // std::cout << "A'(x)="; _A.dump();
 
         // evaluate n_i=v_i/A'_i(x_i)
-        Vec<T> _n(this->gf, k);
+        vec::Vec<T> _n(this->gf, k);
         for (int i = 0; i < k; i++) {
             _n.set(i, this->gf->div(words->get(i), _A.eval(vx.get(i))));
         }
@@ -222,5 +227,8 @@ class FECFNTRS : public FEC<T> {
             output->set(i, S.get(i));
     }
 };
+
+} // namespace fec
+} // namespace nttec
 
 #endif

--- a/src/fecgf2nfftaddrs.h
+++ b/src/fecgf2nfftaddrs.h
@@ -34,8 +34,8 @@ class FECGF2NFFTADDRS : public FEC<T> {
 
         // with this encoder we cannot exactly satisfy users request, we need to
         // pad n = smallest power of 2 and at least (n_parities + n_data)
-        n = arith::_get_smallest_power_of_2<T>(n_data + n_parities);
-        m = arith::_log2<T>(n);
+        n = arith::get_smallest_power_of_2<T>(n_data + n_parities);
+        m = arith::log2<T>(n);
 
         // std::cerr << "n_parities=" << n_parities << "\n";
         // std::cerr << "n_data=" << n_data << "\n";

--- a/src/fecgf2nfftaddrs.h
+++ b/src/fecgf2nfftaddrs.h
@@ -8,14 +8,17 @@
 #include "vec.h"
 #include "vvec.h"
 
+namespace nttec {
+namespace fec {
+
 /**
  * GF_2^n based RS using additive FFT transformation
  */
 template <typename T>
 class FECGF2NFFTADDRS : public FEC<T> {
   private:
-    FFTADD<T>* fft = nullptr;
-    Vec<T>* betas = nullptr;
+    fft::FFTADD<T>* fft = nullptr;
+    vec::Vec<T>* betas = nullptr;
 
   public:
     T n;
@@ -27,22 +30,22 @@ class FECGF2NFFTADDRS : public FEC<T> {
         if (word_size > 16)
             assert(false); // not support yet
         unsigned gf_n = 8 * word_size;
-        this->gf = new GF2N<T>(gf_n);
+        this->gf = new gf::GF2N<T>(gf_n);
 
         // with this encoder we cannot exactly satisfy users request, we need to
         // pad n = smallest power of 2 and at least (n_parities + n_data)
-        n = _get_smallest_power_of_2<T>(n_data + n_parities);
-        m = _log2<T>(n);
+        n = arith::_get_smallest_power_of_2<T>(n_data + n_parities);
+        m = arith::_log2<T>(n);
 
         // std::cerr << "n_parities=" << n_parities << "\n";
         // std::cerr << "n_data=" << n_data << "\n";
         // std::cerr << "n=" << n << "\n";
         // std::cerr << "m=" << m << "\n";
 
-        this->fft = new FFTADD<T>(this->gf, m);
+        this->fft = new fft::FFTADD<T>(this->gf, m);
 
         // subspace spanned by <beta_i>
-        this->betas = new Vec<T>(this->gf, n);
+        this->betas = new vec::Vec<T>(this->gf, n);
         this->fft->compute_B(this->betas);
     }
 
@@ -68,12 +71,12 @@ class FECGF2NFFTADDRS : public FEC<T> {
      * @param words must be n_data
      */
     void encode(
-        Vec<T>* output,
+        vec::Vec<T>* output,
         std::vector<KeyValue*> props,
         off_t offset,
-        Vec<T>* words)
+        vec::Vec<T>* words)
     {
-        VVec<T> vwords(words, n);
+        vec::VVec<T> vwords(words, n);
         fft->fft(output, &vwords);
     }
 
@@ -110,16 +113,16 @@ class FECGF2NFFTADDRS : public FEC<T> {
      * @param words v=(v_0, v_1, ..., v_k-1) k must be exactly n_data
      */
     void decode(
-        Vec<T>* output,
+        vec::Vec<T>* output,
         std::vector<KeyValue*> props,
         off_t offset,
-        Vec<T>* fragments_ids,
-        Vec<T>* words)
+        vec::Vec<T>* fragments_ids,
+        vec::Vec<T>* words)
     {
         int vx_zero = -1;
         int k = this->n_data; // number of fragments received
         // vector x=(x_0, x_1, ..., x_k-1)
-        Vec<T> vx(this->gf, k);
+        vec::Vec<T> vx(this->gf, k);
         for (int i = 0; i < k; i++) {
             int _vx = this->betas->get(fragments_ids->get(i));
             vx.set(i, _vx);
@@ -147,7 +150,7 @@ class FECGF2NFFTADDRS : public FEC<T> {
         // std::cout << "A'(x)="; _A.dump();
 
         // evaluate n_i=v_i/A'_i(x_i)
-        Vec<T> _n(this->gf, k);
+        vec::Vec<T> _n(this->gf, k);
         for (int i = 0; i < k; i++) {
             _n.set(i, this->gf->div(words->get(i), _A.eval(vx.get(i))));
         }
@@ -189,5 +192,8 @@ class FECGF2NFFTADDRS : public FEC<T> {
             output->set(i, S.get(i));
     }
 };
+
+} // namespace fec
+} // namespace nttec
 
 #endif

--- a/src/fecgf2nrs.h
+++ b/src/fecgf2nrs.h
@@ -6,6 +6,9 @@
 #include "gf2n.h"
 #include "mat.h"
 
+namespace nttec {
+namespace fec {
+
 /**
  * GF_2^n based RS (Cauchy or Vandermonde)
  */
@@ -36,7 +39,7 @@ class FECGF2NRS : public FEC<T> {
         if (word_size > 16)
             assert(false); // not support yet
         unsigned gf_n = 8 * word_size;
-        this->gf = new GF2N<T>(gf_n);
+        this->gf = new gf::GF2N<T>(gf_n);
 
         this->mat = new Mat<T>(this->gf, n_parities, n_data);
         if (type == CAUCHY) {
@@ -62,10 +65,10 @@ class FECGF2NRS : public FEC<T> {
     }
 
     void encode(
-        Vec<T>* output,
+        vec::Vec<T>* output,
         std::vector<KeyValue*> props,
         off_t offset,
-        Vec<T>* words)
+        vec::Vec<T>* words)
     {
         mat->mul(output, words);
     }
@@ -95,14 +98,17 @@ class FECGF2NRS : public FEC<T> {
     }
 
     void decode(
-        Vec<T>* output,
+        vec::Vec<T>* output,
         std::vector<KeyValue*> props,
         off_t offset,
-        Vec<T>* fragments_ids,
-        Vec<T>* words)
+        vec::Vec<T>* fragments_ids,
+        vec::Vec<T>* words)
     {
         decode_mat->mul(output, words);
     }
 };
+
+} // namespace fec
+} // namespace nttec
 
 #endif

--- a/src/fecgfpfftrs.h
+++ b/src/fecgfpfftrs.h
@@ -62,7 +62,7 @@ class FECGFPFFTRS : public FEC<T> {
 
         this->gf = new gf::GFP<T>(gf_p);
         assert(
-            arith::_jacobi<T>(this->gf->get_prime_root(), this->gf->card())
+            arith::jacobi<T>(this->gf->get_prime_root(), this->gf->card())
             == -1);
 
         // with this encoder we cannot exactly satisfy users request, we need to
@@ -78,7 +78,7 @@ class FECGFPFFTRS : public FEC<T> {
         // std::cerr << "n=" << n << "\n";
         // std::cerr << "r=" << r << "\n";
 
-        if (arith::_is_power_of_2<T>(n))
+        if (arith::is_power_of_2<T>(n))
             this->fft = new fft::FFT2K<T>(this->gf, n);
         else
             this->fft = new fft::FFTCT<T>(this->gf, n);

--- a/src/fft2.h
+++ b/src/fft2.h
@@ -5,6 +5,9 @@
 #include "dft.h"
 #include "vec.h"
 
+namespace nttec {
+namespace fft {
+
 /**
  * Algorithm for FFT(n=2)
  *  Since w^2 = 1 => w = -1 or w = 1 (we exclude)
@@ -13,18 +16,18 @@
 template <typename T>
 class FFT2 : public DFT<T> {
   public:
-    explicit FFT2(GF<T>* gf);
+    explicit FFT2(gf::GF<T>* gf);
     ~FFT2();
-    void fft(Vec<T>* output, Vec<T>* input);
-    void ifft(Vec<T>* output, Vec<T>* input);
-    void fft_inv(Vec<T>* output, Vec<T>* input);
-    void fft(Vecp<T>* output, Vecp<T>* input);
-    void ifft(Vecp<T>* output, Vecp<T>* input);
-    void fft_inv(Vecp<T>* output, Vecp<T>* input);
+    void fft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void ifft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void fft_inv(vec::Vec<T>* output, vec::Vec<T>* input);
+    void fft(vec::Vecp<T>* output, vec::Vecp<T>* input);
+    void ifft(vec::Vecp<T>* output, vec::Vecp<T>* input);
+    void fft_inv(vec::Vecp<T>* output, vec::Vecp<T>* input);
 };
 
 template <typename T>
-FFT2<T>::FFT2(GF<T>* gf) : DFT<T>(gf, 2)
+FFT2<T>::FFT2(gf::GF<T>* gf) : DFT<T>(gf, 2)
 {
 }
 
@@ -34,7 +37,7 @@ FFT2<T>::~FFT2()
 }
 
 template <typename T>
-void FFT2<T>::fft(Vec<T>* output, Vec<T>* input)
+void FFT2<T>::fft(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     T a = input->get(0);
     T b = input->get(1);
@@ -48,13 +51,13 @@ void FFT2<T>::fft(Vec<T>* output, Vec<T>* input)
  *
  */
 template <typename T>
-void FFT2<T>::fft_inv(Vec<T>* output, Vec<T>* input)
+void FFT2<T>::fft_inv(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     fft(output, input);
 }
 
 template <typename T>
-void FFT2<T>::ifft(Vec<T>* output, Vec<T>* input)
+void FFT2<T>::ifft(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     fft_inv(output, input);
     if (this->inv_n_mod_p > 1)
@@ -62,7 +65,7 @@ void FFT2<T>::ifft(Vec<T>* output, Vec<T>* input)
 }
 
 template <typename T>
-void FFT2<T>::fft(Vecp<T>* output, Vecp<T>* input)
+void FFT2<T>::fft(vec::Vecp<T>* output, vec::Vecp<T>* input)
 {
     output->copy(input);
     size_t buf_len = input->get_size();
@@ -77,17 +80,20 @@ void FFT2<T>::fft(Vecp<T>* output, Vecp<T>* input)
  *
  */
 template <typename T>
-void FFT2<T>::fft_inv(Vecp<T>* output, Vecp<T>* input)
+void FFT2<T>::fft_inv(vec::Vecp<T>* output, vec::Vecp<T>* input)
 {
     fft(output, input);
 }
 
 template <typename T>
-void FFT2<T>::ifft(Vecp<T>* output, Vecp<T>* input)
+void FFT2<T>::ifft(vec::Vecp<T>* output, vec::Vecp<T>* input)
 {
     fft_inv(output, input);
     if (this->inv_n_mod_p > 1)
         this->gf->mul_vec_to_vecp(this->vec_inv_n, output, output);
 }
+
+} // namespace fft
+} // namespace nttec
 
 #endif

--- a/src/fft2k.h
+++ b/src/fft2k.h
@@ -5,6 +5,9 @@
 #include "dft.h"
 #include "fft2.h"
 
+namespace nttec {
+namespace fft {
+
 /**
  * Cooley-Tukey Algorithm
  *
@@ -28,36 +31,36 @@ class FFT2K : public DFT<T> {
     T w;
     T inv_w;
     size_t pkt_size;
-    Vec<T>* W = nullptr;
-    Vec<T>* inv_W = nullptr;
-    Vec<T>* W_half = nullptr;
-    Vec<T>* inv_W_half = nullptr;
+    vec::Vec<T>* W = nullptr;
+    vec::Vec<T>* inv_W = nullptr;
+    vec::Vec<T>* W_half = nullptr;
+    vec::Vec<T>* inv_W_half = nullptr;
 
     FFT2<T>* fft2 = nullptr;
     FFT2K<T>* fftk = nullptr;
 
-    Vec<T>* even = nullptr;
-    Vec<T>* _even = nullptr;
-    Vec<T>* odd = nullptr;
-    Vec<T>* _odd = nullptr;
-    V2Vec<T>* veven = nullptr;
-    V2Vec<T>* vodd = nullptr;
+    vec::Vec<T>* even = nullptr;
+    vec::Vec<T>* _even = nullptr;
+    vec::Vec<T>* odd = nullptr;
+    vec::Vec<T>* _odd = nullptr;
+    vec::V2Vec<T>* veven = nullptr;
+    vec::V2Vec<T>* vodd = nullptr;
 
-    Vecp<T>* tmp_buf = nullptr;
+    vec::Vecp<T>* tmp_buf = nullptr;
 
   public:
-    FFT2K(GF<T>* gf, int n, size_t pkt_size = 0, int N = 0);
+    FFT2K(gf::GF<T>* gf, int n, size_t pkt_size = 0, int N = 0);
     ~FFT2K();
-    void fft(Vec<T>* output, Vec<T>* input);
-    void ifft(Vec<T>* output, Vec<T>* input);
-    void fft_inv(Vec<T>* output, Vec<T>* input);
-    void fft(Vecp<T>* output, Vecp<T>* input);
-    void ifft(Vecp<T>* output, Vecp<T>* input);
-    void fft_inv(Vecp<T>* output, Vecp<T>* input);
+    void fft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void ifft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void fft_inv(vec::Vec<T>* output, vec::Vec<T>* input);
+    void fft(vec::Vecp<T>* output, vec::Vecp<T>* input);
+    void ifft(vec::Vecp<T>* output, vec::Vecp<T>* input);
+    void fft_inv(vec::Vecp<T>* output, vec::Vecp<T>* input);
 
   private:
-    void _fftp(Vecp<T>* output, Vecp<T>* input, bool inv);
-    void _fft(Vec<T>* output, Vec<T>* input, bool inv);
+    void _fftp(vec::Vecp<T>* output, vec::Vecp<T>* input, bool inv);
+    void _fft(vec::Vec<T>* output, vec::Vec<T>* input, bool inv);
 };
 
 /**
@@ -72,7 +75,7 @@ class FFT2K : public DFT<T> {
  * @return
  */
 template <typename T>
-FFT2K<T>::FFT2K(GF<T>* gf, int n, size_t pkt_size, int N) : DFT<T>(gf, n)
+FFT2K<T>::FFT2K(gf::GF<T>* gf, int n, size_t pkt_size, int N) : DFT<T>(gf, n)
 {
     w = gf->get_nth_root(n);
     inv_w = gf->inv(w);
@@ -85,13 +88,13 @@ FFT2K<T>::FFT2K(GF<T>* gf, int n, size_t pkt_size, int N) : DFT<T>(gf, n)
         bypass = false;
         k = n / 2;
 
-        W = new Vec<T>(gf, n);
-        inv_W = new Vec<T>(gf, n);
+        W = new vec::Vec<T>(gf, n);
+        inv_W = new vec::Vec<T>(gf, n);
         gf->compute_omegas(W, n, w);
         gf->compute_omegas(inv_W, n, inv_w);
 
-        W_half = new Vec<T>(gf, k);
-        inv_W_half = new Vec<T>(gf, k);
+        W_half = new vec::Vec<T>(gf, k);
+        inv_W_half = new vec::Vec<T>(gf, k);
         for (int i = 0; i < k; i++) {
             W_half->set(i, W->get(i));
             inv_W_half->set(i, inv_W->get(i));
@@ -99,15 +102,15 @@ FFT2K<T>::FFT2K(GF<T>* gf, int n, size_t pkt_size, int N) : DFT<T>(gf, n)
 
         this->fftk = new FFT2K<T>(gf, k, pkt_size, this->N);
 
-        this->even = new Vec<T>(this->gf, k);
-        this->_even = new Vec<T>(this->gf, k);
-        this->veven = new V2Vec<T>(this->_even);
-        this->odd = new Vec<T>(this->gf, k);
-        this->_odd = new Vec<T>(this->gf, k);
-        this->vodd = new V2Vec<T>(this->_odd);
+        this->even = new vec::Vec<T>(this->gf, k);
+        this->_even = new vec::Vec<T>(this->gf, k);
+        this->veven = new vec::V2Vec<T>(this->_even);
+        this->odd = new vec::Vec<T>(this->gf, k);
+        this->_odd = new vec::Vec<T>(this->gf, k);
+        this->vodd = new vec::V2Vec<T>(this->_odd);
 
         if (this->pkt_size > 0)
-            this->tmp_buf = new Vecp<T>(k, pkt_size);
+            this->tmp_buf = new vec::Vecp<T>(k, pkt_size);
     } else {
         bypass = true;
         this->fft2 = new FFT2<T>(gf);
@@ -149,7 +152,7 @@ FFT2K<T>::~FFT2K()
 }
 
 template <typename T>
-void FFT2K<T>::_fft(Vec<T>* output, Vec<T>* input, bool inv)
+void FFT2K<T>::_fft(vec::Vec<T>* output, vec::Vec<T>* input, bool inv)
 {
     for (int i = 0; i < this->n; i++) {
         if (i % 2 == 0)
@@ -176,7 +179,7 @@ void FFT2K<T>::_fft(Vec<T>* output, Vec<T>* input, bool inv)
 }
 
 template <typename T>
-void FFT2K<T>::fft(Vec<T>* output, Vec<T>* input)
+void FFT2K<T>::fft(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     // input->dump();
 
@@ -187,7 +190,7 @@ void FFT2K<T>::fft(Vec<T>* output, Vec<T>* input)
 }
 
 template <typename T>
-void FFT2K<T>::fft_inv(Vec<T>* output, Vec<T>* input)
+void FFT2K<T>::fft_inv(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     if (bypass)
         return fft2->fft_inv(output, input);
@@ -196,7 +199,7 @@ void FFT2K<T>::fft_inv(Vec<T>* output, Vec<T>* input)
 }
 
 template <typename T>
-void FFT2K<T>::ifft(Vec<T>* output, Vec<T>* input)
+void FFT2K<T>::ifft(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     fft_inv(output, input);
 
@@ -208,20 +211,20 @@ void FFT2K<T>::ifft(Vec<T>* output, Vec<T>* input)
 }
 
 template <typename T>
-void FFT2K<T>::_fftp(Vecp<T>* output, Vecp<T>* input, bool inv)
+void FFT2K<T>::_fftp(vec::Vecp<T>* output, vec::Vecp<T>* input, bool inv)
 {
     int half = this->n / 2;
     size_t size = input->get_size();
     std::vector<T*> even_mem(half, nullptr);
     std::vector<T*> odd_mem(half, nullptr);
-    Vecp<T> i_even(half, size, &even_mem);
-    Vecp<T> i_odd(half, size, &odd_mem);
+    vec::Vecp<T> i_even(half, size, &even_mem);
+    vec::Vecp<T> i_odd(half, size, &odd_mem);
 
     // separate even and odd elements of input
     input->separate_even_odd(&i_even, &i_odd);
 
-    Vecp<T> o_even(output, 0, half);
-    Vecp<T> o_odd(output, half, this->n);
+    vec::Vecp<T> o_even(output, 0, half);
+    vec::Vecp<T> o_odd(output, half, this->n);
 
     if (inv) {
         fftk->fft_inv(&o_even, &i_even);
@@ -236,9 +239,9 @@ void FFT2K<T>::_fftp(Vecp<T>* output, Vecp<T>* input, bool inv)
      * output[i] = even[i] - w * odd[i] otherwise
      */
     // prepare tm_buf
-    Vecp<T>* _o_odd = nullptr;
+    vec::Vecp<T>* _o_odd = nullptr;
     if (this->pkt_size == 0) {
-        _o_odd = new Vecp<T>(half, size);
+        _o_odd = new vec::Vecp<T>(half, size);
         tmp_buf = _o_odd;
     }
 
@@ -258,7 +261,7 @@ void FFT2K<T>::_fftp(Vecp<T>* output, Vecp<T>* input, bool inv)
 }
 
 template <typename T>
-void FFT2K<T>::fft(Vecp<T>* output, Vecp<T>* input)
+void FFT2K<T>::fft(vec::Vecp<T>* output, vec::Vecp<T>* input)
 {
     if (bypass)
         return fft2->fft(output, input);
@@ -267,7 +270,7 @@ void FFT2K<T>::fft(Vecp<T>* output, Vecp<T>* input)
 }
 
 template <typename T>
-void FFT2K<T>::fft_inv(Vecp<T>* output, Vecp<T>* input)
+void FFT2K<T>::fft_inv(vec::Vecp<T>* output, vec::Vecp<T>* input)
 {
     if (bypass)
         return fft2->fft_inv(output, input);
@@ -276,7 +279,7 @@ void FFT2K<T>::fft_inv(Vecp<T>* output, Vecp<T>* input)
 }
 
 template <typename T>
-void FFT2K<T>::ifft(Vecp<T>* output, Vecp<T>* input)
+void FFT2K<T>::ifft(vec::Vecp<T>* output, vec::Vecp<T>* input)
 {
     fft_inv(output, input);
 
@@ -286,5 +289,8 @@ void FFT2K<T>::ifft(Vecp<T>* output, Vecp<T>* input)
     if ((this->k == this->N / 2) && (this->inv_n_mod_p > 1))
         this->gf->mul_vec_to_vecp(this->vec_inv_n, output, output);
 }
+
+} // namespace fft
+} // namespace nttec
 
 #endif

--- a/src/fftadd.h
+++ b/src/fftadd.h
@@ -71,7 +71,7 @@ class FFTADD : public DFT<T> {
  */
 template <typename T>
 FFTADD<T>::FFTADD(gf::GF<T>* gf, T m, vec::Vec<T>* betas)
-    : DFT<T>(gf, arith::_exp2<T>(m))
+    : DFT<T>(gf, arith::exp2<T>(m))
 {
     assert(m >= 1);
     this->m = m;
@@ -98,7 +98,7 @@ FFTADD<T>::FFTADD(gf::GF<T>* gf, T m, vec::Vec<T>* betas)
     this->beta_m_powers = new vec::Vec<T>(gf, this->n);
     this->compute_beta_m_powers();
     if (m > 1) {
-        this->k = arith::_exp2<T>(m - 1);
+        this->k = arith::exp2<T>(m - 1);
 
         // compute gammas and deltas
         this->gammas = new vec::Vec<T>(gf, m - 1);
@@ -204,20 +204,20 @@ void FFTADD<T>::compute_subspace(vec::Vec<T>* basis, vec::Vec<T>* subspace)
     int size = 1;
     int dim = basis->get_n();
     T val = 0;
-    assert(subspace->get_n() == arith::_exp2<T>(dim));
+    assert(subspace->get_n() == arith::exp2<T>(dim));
     // index of element in G
     std::vector<int> ids;
     // create sequence 2^i
     vec::Vec<T> powers2(this->gf, dim);
     for (i = 0; i < dim; i++)
-        powers2.set(i, arith::_exp2<T>(i));
+        powers2.set(i, arith::exp2<T>(i));
 
     ids.push_back(0);
     subspace->set(0, 0);
     for (i = 0; i < dim; i++) {
         for (j = size - 1; j >= 0; j--) {
             int id = this->gf->add(ids.at(j), powers2.get(i));
-            int diff = arith::_log2<T>(this->gf->add(id, ids.back()));
+            int diff = arith::log2<T>(this->gf->add(id, ids.back()));
             val = this->gf->add(val, basis->get(diff));
             subspace->set(id, val);
             // for next i
@@ -444,7 +444,7 @@ void FFTADD<T>::taylor_expand_t2(vec::Vec<T>* input, int n, bool do_copy)
 template <typename T>
 void FFTADD<T>::_taylor_expand_t2(vec::Vec<T>* input, int n, int _k, int s_deg)
 {
-    int deg2 = arith::_exp2<T>(_k);
+    int deg2 = arith::exp2<T>(_k);
     int deg0 = 2 * deg2;
     int deg1 = deg0 - deg2;
 
@@ -575,7 +575,7 @@ void FFTADD<T>::_taylor_expand(vec::Vec<T>* input, int n, int t)
 {
     // find k s.t. t2^k < n <= 2 *t2^k
     int k = find_k(n, t);
-    int deg2 = arith::_exp2<T>(k);
+    int deg2 = arith::exp2<T>(k);
     int deg0 = t * deg2;
     int deg1 = deg0 - deg2;
     int g1deg = n - deg0;

--- a/src/fftct.h
+++ b/src/fftct.h
@@ -87,7 +87,7 @@ FFTCT<T>::FFTCT(gf::GF<T>* gf, T n, int id, std::vector<T>* factors, T _w)
     if (factors == nullptr) {
         this->prime_factors = new std::vector<T>();
         first_layer_fft = true;
-        arith::_get_prime_factors<T>(n, this->prime_factors);
+        arith::get_prime_factors<T>(n, this->prime_factors);
         // w is of order-n
         w = gf->get_nth_root(n);
     } else {

--- a/src/fftct.h
+++ b/src/fftct.h
@@ -7,6 +7,9 @@
 #include "fft2.h"
 #include "vcvec.h"
 
+namespace nttec {
+namespace fft {
+
 /**
  * Cooley-Tukey FFT algorithm
  *  Implementation based on S.K. Matra's slides
@@ -44,9 +47,9 @@ class FFTCT : public DFT<T> {
     T n1;
     T n2;
     T w, w1, w2, inv_w;
-    Vec<T>* G = nullptr;
-    VcVec<T>* Y = nullptr;
-    VcVec<T>* X = nullptr;
+    vec::Vec<T>* G = nullptr;
+    vec::VcVec<T>* Y = nullptr;
+    vec::VcVec<T>* X = nullptr;
     DFT<T>* dft_outer = nullptr;
     DFT<T>* dft_inner = nullptr;
     std::vector<T>* prime_factors = nullptr;
@@ -54,18 +57,18 @@ class FFTCT : public DFT<T> {
 
   public:
     FFTCT(
-        GF<T>* gf,
+        gf::GF<T>* gf,
         T n,
         int id = 0,
         std::vector<T>* factors = nullptr,
         T _w = 0);
     ~FFTCT();
-    void fft(Vec<T>* output, Vec<T>* input);
-    void ifft(Vec<T>* output, Vec<T>* input);
-    void fft_inv(Vec<T>* output, Vec<T>* input);
+    void fft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void ifft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void fft_inv(vec::Vec<T>* output, vec::Vec<T>* input);
 
   private:
-    void _fft(Vec<T>* output, Vec<T>* input, bool inv);
+    void _fft(vec::Vec<T>* output, vec::Vec<T>* input, bool inv);
 };
 
 /**
@@ -78,13 +81,13 @@ class FFTCT : public DFT<T> {
  * @return
  */
 template <typename T>
-FFTCT<T>::FFTCT(GF<T>* gf, T n, int id, std::vector<T>* factors, T _w)
+FFTCT<T>::FFTCT(gf::GF<T>* gf, T n, int id, std::vector<T>* factors, T _w)
     : DFT<T>(gf, n)
 {
     if (factors == nullptr) {
         this->prime_factors = new std::vector<T>();
         first_layer_fft = true;
-        _get_prime_factors<T>(n, this->prime_factors);
+        arith::_get_prime_factors<T>(n, this->prime_factors);
         // w is of order-n
         w = gf->get_nth_root(n);
     } else {
@@ -112,9 +115,9 @@ FFTCT<T>::FFTCT(GF<T>* gf, T n, int id, std::vector<T>* factors, T _w)
         // else
         this->dft_inner =
             new FFTCT<T>(gf, _n2, id + 1, this->prime_factors, w2);
-        this->G = new Vec<T>(this->gf, this->n);
-        this->Y = new VcVec<T>(this->G);
-        this->X = new VcVec<T>(this->G);
+        this->G = new vec::Vec<T>(this->gf, this->n);
+        this->Y = new vec::VcVec<T>(this->G);
+        this->X = new vec::VcVec<T>(this->G);
     } else
         loop = false;
 }
@@ -160,7 +163,7 @@ void FFTCT<T>::mul_twiddle_factors(bool inv)
 }
 
 template <typename T>
-void FFTCT<T>::_fft(Vec<T>* output, Vec<T>* input, bool inv)
+void FFTCT<T>::_fft(vec::Vec<T>* output, vec::Vec<T>* input, bool inv)
 {
     X->set_vec(input);
     X->set_len(n2);
@@ -195,7 +198,7 @@ void FFTCT<T>::_fft(Vec<T>* output, Vec<T>* input, bool inv)
 }
 
 template <typename T>
-void FFTCT<T>::fft(Vec<T>* output, Vec<T>* input)
+void FFTCT<T>::fft(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     if (!loop)
         return dft_outer->fft(output, input);
@@ -204,7 +207,7 @@ void FFTCT<T>::fft(Vec<T>* output, Vec<T>* input)
 }
 
 template <typename T>
-void FFTCT<T>::fft_inv(Vec<T>* output, Vec<T>* input)
+void FFTCT<T>::fft_inv(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     if (!loop)
         dft_outer->fft_inv(output, input);
@@ -213,7 +216,7 @@ void FFTCT<T>::fft_inv(Vec<T>* output, Vec<T>* input)
 }
 
 template <typename T>
-void FFTCT<T>::ifft(Vec<T>* output, Vec<T>* input)
+void FFTCT<T>::ifft(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     fft_inv(output, input);
 
@@ -225,5 +228,8 @@ void FFTCT<T>::ifft(Vec<T>* output, Vec<T>* input)
         output->mul_scalar(this->inv_n_mod_p);
     }
 }
+
+} // namespace fft
+} // namespace nttec
 
 #endif

--- a/src/fftln.h
+++ b/src/fftln.h
@@ -6,6 +6,9 @@
 #include "mat.h"
 #include "vec.h"
 
+namespace nttec {
+namespace fft {
+
 /**
  * Algorithm for very large n=2^l
  */
@@ -15,35 +18,35 @@ class FFTLN : public DFT<T> {
     int l;
     T w;
     T inv_w;
-    Vec<T>* W;
-    Vec<T>* inv_W;
+    vec::Vec<T>* W;
+    vec::Vec<T>* inv_W;
     Mat<T>* tmp2;
     Mat<T>* tmp3;
     Mat<T>* tmp4;
-    Vec<T>* tmp5;
+    vec::Vec<T>* tmp5;
     int _get_p(int i, int j);
     int _get_p0(int i, int j, int s);
     int _get_p1(int i, int j, int s);
     void _pre_compute_consts();
-    void _fft(Vec<T>* output, Vec<T>* input, Vec<T>* _W);
+    void _fft(vec::Vec<T>* output, vec::Vec<T>* input, vec::Vec<T>* _W);
 
   public:
-    FFTLN(GF<T>* gf, int l, T w);
+    FFTLN(gf::GF<T>* gf, int l, T w);
     ~FFTLN();
-    void fft(Vec<T>* output, Vec<T>* input);
-    void ifft(Vec<T>* output, Vec<T>* input);
-    void fft_inv(Vec<T>* output, Vec<T>* input);
+    void fft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void ifft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void fft_inv(vec::Vec<T>* output, vec::Vec<T>* input);
 };
 
 template <typename T>
-FFTLN<T>::FFTLN(GF<T>* gf, int l, T w) : DFT<T>(gf, _exp2<T>(l))
+FFTLN<T>::FFTLN(gf::GF<T>* gf, int l, T w) : DFT<T>(gf, arith::_exp2<T>(l))
 {
     this->l = l;
     this->w = w;
     this->inv_w = gf->inv(w);
 
-    this->W = new Vec<T>(gf, this->n + 1);
-    this->inv_W = new Vec<T>(gf, this->n + 1);
+    this->W = new vec::Vec<T>(gf, this->n + 1);
+    this->inv_W = new vec::Vec<T>(gf, this->n + 1);
     gf->compute_omegas_cached(W, this->n, w);
     gf->compute_omegas_cached(inv_W, this->n, inv_w);
 
@@ -136,7 +139,7 @@ void FFTLN<T>::_pre_compute_consts()
     tmp2 = new Mat<T>(this->gf, this->l + 1, this->n);
     tmp3 = new Mat<T>(this->gf, this->l + 1, this->n);
     tmp4 = new Mat<T>(this->gf, this->l + 1, this->n);
-    tmp5 = new Vec<T>(this->gf, this->n);
+    tmp5 = new vec::Vec<T>(this->gf, this->n);
 
     tmp2->zero_fill();
     tmp3->zero_fill();
@@ -147,19 +150,21 @@ void FFTLN<T>::_pre_compute_consts()
         for (int j = 0; j <= this->n - 1; j++) {
             T _tmp1 = 0;
             for (int k = 1; k <= i; k++)
-                _tmp1 += _get_p(j, this->l - i + k) * _exp2<T>(i - k);
+                _tmp1 += _get_p(j, this->l - i + k) * arith::_exp2<T>(i - k);
 
             T _tmp2 = 0;
             for (int k = 1; k <= this->l; k++)
-                _tmp2 += _get_p0(j, k, this->l - i + 1) * _exp2<T>(k - 1);
+                _tmp2 +=
+                    _get_p0(j, k, this->l - i + 1) * arith::_exp2<T>(k - 1);
             tmp2->set(i, j, _tmp2);
 
             T _tmp3 = 0;
             for (int k = 1; k <= this->l; k++)
-                _tmp3 += _get_p1(j, k, this->l - i + 1) * _exp2<T>(k - 1);
+                _tmp3 +=
+                    _get_p1(j, k, this->l - i + 1) * arith::_exp2<T>(k - 1);
             tmp3->set(i, j, _tmp3);
 
-            T _tmp4 = _tmp1 * _exp2<T>(this->l - i);
+            T _tmp4 = _tmp1 * arith::_exp2<T>(this->l - i);
             tmp4->set(i, j, _tmp4);
         }
     }
@@ -167,13 +172,13 @@ void FFTLN<T>::_pre_compute_consts()
     for (int i = 0; i <= this->n - 1; i++) {
         T _tmp5 = 0;
         for (int k = 1; k <= this->l; k++)
-            _tmp5 += _get_p(i, this->l - k + 1) * _exp2<T>(k - 1);
+            _tmp5 += _get_p(i, this->l - k + 1) * arith::_exp2<T>(k - 1);
         tmp5->set(i, _tmp5);
     }
 }
 
 template <typename T>
-void FFTLN<T>::_fft(Vec<T>* output, Vec<T>* input, Vec<T>* _W)
+void FFTLN<T>::_fft(vec::Vec<T>* output, vec::Vec<T>* input, vec::Vec<T>* _W)
 {
     Mat<T> phi(this->gf, this->l + 1, this->n);
 
@@ -197,23 +202,26 @@ void FFTLN<T>::_fft(Vec<T>* output, Vec<T>* input, Vec<T>* _W)
 }
 
 template <typename T>
-void FFTLN<T>::fft(Vec<T>* output, Vec<T>* input)
+void FFTLN<T>::fft(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     _fft(output, input, W);
 }
 
 template <typename T>
-void FFTLN<T>::fft_inv(Vec<T>* output, Vec<T>* input)
+void FFTLN<T>::fft_inv(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     _fft(output, input, inv_W);
 }
 
 template <typename T>
-void FFTLN<T>::ifft(Vec<T>* output, Vec<T>* input)
+void FFTLN<T>::ifft(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     fft_inv(output, input);
     if (this->inv_n_mod_p > 1)
         output->mul_scalar(this->inv_n_mod_p);
 }
+
+} // namespace fft
+} // namespace nttec
 
 #endif

--- a/src/fftln.h
+++ b/src/fftln.h
@@ -39,7 +39,7 @@ class FFTLN : public DFT<T> {
 };
 
 template <typename T>
-FFTLN<T>::FFTLN(gf::GF<T>* gf, int l, T w) : DFT<T>(gf, arith::_exp2<T>(l))
+FFTLN<T>::FFTLN(gf::GF<T>* gf, int l, T w) : DFT<T>(gf, arith::exp2<T>(l))
 {
     this->l = l;
     this->w = w;
@@ -150,21 +150,19 @@ void FFTLN<T>::_pre_compute_consts()
         for (int j = 0; j <= this->n - 1; j++) {
             T _tmp1 = 0;
             for (int k = 1; k <= i; k++)
-                _tmp1 += _get_p(j, this->l - i + k) * arith::_exp2<T>(i - k);
+                _tmp1 += _get_p(j, this->l - i + k) * arith::exp2<T>(i - k);
 
             T _tmp2 = 0;
             for (int k = 1; k <= this->l; k++)
-                _tmp2 +=
-                    _get_p0(j, k, this->l - i + 1) * arith::_exp2<T>(k - 1);
+                _tmp2 += _get_p0(j, k, this->l - i + 1) * arith::exp2<T>(k - 1);
             tmp2->set(i, j, _tmp2);
 
             T _tmp3 = 0;
             for (int k = 1; k <= this->l; k++)
-                _tmp3 +=
-                    _get_p1(j, k, this->l - i + 1) * arith::_exp2<T>(k - 1);
+                _tmp3 += _get_p1(j, k, this->l - i + 1) * arith::exp2<T>(k - 1);
             tmp3->set(i, j, _tmp3);
 
-            T _tmp4 = _tmp1 * arith::_exp2<T>(this->l - i);
+            T _tmp4 = _tmp1 * arith::exp2<T>(this->l - i);
             tmp4->set(i, j, _tmp4);
         }
     }
@@ -172,7 +170,7 @@ void FFTLN<T>::_pre_compute_consts()
     for (int i = 0; i <= this->n - 1; i++) {
         T _tmp5 = 0;
         for (int k = 1; k <= this->l; k++)
-            _tmp5 += _get_p(i, this->l - k + 1) * arith::_exp2<T>(k - 1);
+            _tmp5 += _get_p(i, this->l - k + 1) * arith::exp2<T>(k - 1);
         tmp5->set(i, _tmp5);
     }
 }

--- a/src/fftpf.h
+++ b/src/fftpf.h
@@ -92,7 +92,7 @@ FFTPF<T>::FFTPF(gf::GF<T>* gf, T n, int id, std::vector<T>* factors, T _w)
     if (factors == nullptr) {
         this->prime_factors = new std::vector<T>();
         first_layer_fft = true;
-        arith::_get_coprime_factors<T>(n, this->prime_factors);
+        arith::get_coprime_factors<T>(n, this->prime_factors);
         // w is of order-n
         w = gf->get_nth_root(n);
     } else {
@@ -118,7 +118,7 @@ FFTPF<T>::FFTPF(gf::GF<T>* gf, T n, int id, std::vector<T>* factors, T _w)
         loop = true;
         w2 = gf->exp(w, n1); // order of w2 = n2
         T _n2 = n / n1;
-        if (arith::_is_power_of_2<T>(_n2))
+        if (arith::is_power_of_2<T>(_n2))
             this->dft_inner = new FFT2K<T>(gf, _n2);
         else
             this->dft_inner =

--- a/src/fftpf.h
+++ b/src/fftpf.h
@@ -10,6 +10,9 @@
 #include "vcvec.h"
 #include "vec.h"
 
+namespace nttec {
+namespace fft {
+
 /**
  * Prime-factor FFT algorithm
  *  https://en.wikipedia.org/wiki/Prime-factor_FFT_algorithm
@@ -49,27 +52,27 @@ class FFTPF : public DFT<T> {
     T n2;
     T w, w1, w2;
     T a, b, c, d;
-    Vec<T>* G = nullptr;
-    VcVec<T>* Y = nullptr;
-    VcVec<T>* X = nullptr;
+    vec::Vec<T>* G = nullptr;
+    vec::VcVec<T>* Y = nullptr;
+    vec::VcVec<T>* X = nullptr;
     DFT<T>* dft_outer = nullptr;
     DFT<T>* dft_inner = nullptr;
     std::vector<T>* prime_factors = nullptr;
 
   public:
     FFTPF(
-        GF<T>* gf,
+        gf::GF<T>* gf,
         T n,
         int id = 0,
         std::vector<T>* factors = nullptr,
         T _w = 0);
     ~FFTPF();
-    void fft(Vec<T>* output, Vec<T>* input);
-    void ifft(Vec<T>* output, Vec<T>* input);
-    void fft_inv(Vec<T>* output, Vec<T>* input);
+    void fft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void ifft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void fft_inv(vec::Vec<T>* output, vec::Vec<T>* input);
 
   private:
-    void _fft(Vec<T>* output, Vec<T>* input, bool inv);
+    void _fft(vec::Vec<T>* output, vec::Vec<T>* input, bool inv);
     T _inverse_mod(T nb, T mod);
 };
 
@@ -83,13 +86,13 @@ class FFTPF : public DFT<T> {
  * @return
  */
 template <typename T>
-FFTPF<T>::FFTPF(GF<T>* gf, T n, int id, std::vector<T>* factors, T _w)
+FFTPF<T>::FFTPF(gf::GF<T>* gf, T n, int id, std::vector<T>* factors, T _w)
     : DFT<T>(gf, n)
 {
     if (factors == nullptr) {
         this->prime_factors = new std::vector<T>();
         first_layer_fft = true;
-        _get_coprime_factors<T>(n, this->prime_factors);
+        arith::_get_coprime_factors<T>(n, this->prime_factors);
         // w is of order-n
         w = gf->get_nth_root(n);
     } else {
@@ -115,14 +118,14 @@ FFTPF<T>::FFTPF(GF<T>* gf, T n, int id, std::vector<T>* factors, T _w)
         loop = true;
         w2 = gf->exp(w, n1); // order of w2 = n2
         T _n2 = n / n1;
-        if (_is_power_of_2<T>(_n2))
+        if (arith::_is_power_of_2<T>(_n2))
             this->dft_inner = new FFT2K<T>(gf, _n2);
         else
             this->dft_inner =
                 new FFTCT<T>(gf, _n2, id + 1, this->prime_factors, w2);
-        this->G = new Vec<T>(this->gf, this->n);
-        this->Y = new VcVec<T>(this->G);
-        this->X = new VcVec<T>(this->G);
+        this->G = new vec::Vec<T>(this->gf, this->n);
+        this->Y = new vec::VcVec<T>(this->G);
+        this->X = new vec::VcVec<T>(this->G);
     } else
         loop = false;
 }
@@ -159,7 +162,7 @@ T FFTPF<T>::_inverse_mod(T nb, T mod)
 }
 
 template <typename T>
-void FFTPF<T>::_fft(Vec<T>* output, Vec<T>* input, bool inv)
+void FFTPF<T>::_fft(vec::Vec<T>* output, vec::Vec<T>* input, bool inv)
 {
     X->set_vec(input);
     X->set_len(n2);
@@ -191,7 +194,7 @@ void FFTPF<T>::_fft(Vec<T>* output, Vec<T>* input, bool inv)
 }
 
 template <typename T>
-void FFTPF<T>::fft(Vec<T>* output, Vec<T>* input)
+void FFTPF<T>::fft(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     if (!loop)
         return dft_outer->fft(output, input);
@@ -200,7 +203,7 @@ void FFTPF<T>::fft(Vec<T>* output, Vec<T>* input)
 }
 
 template <typename T>
-void FFTPF<T>::fft_inv(Vec<T>* output, Vec<T>* input)
+void FFTPF<T>::fft_inv(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     if (!loop)
         dft_outer->fft_inv(output, input);
@@ -209,7 +212,7 @@ void FFTPF<T>::fft_inv(Vec<T>* output, Vec<T>* input)
 }
 
 template <typename T>
-void FFTPF<T>::ifft(Vec<T>* output, Vec<T>* input)
+void FFTPF<T>::ifft(vec::Vec<T>* output, vec::Vec<T>* input)
 {
     fft_inv(output, input);
 
@@ -220,5 +223,8 @@ void FFTPF<T>::ifft(Vec<T>* output, Vec<T>* input)
         output->mul_scalar(this->inv_n_mod_p);
     }
 }
+
+} // namespace fft
+} // namespace nttec
 
 #endif

--- a/src/gf.h
+++ b/src/gf.h
@@ -8,6 +8,11 @@
 #include "core.h"
 #include "rn.h"
 
+namespace nttec {
+
+/** Galois Fields handling. */
+namespace gf {
+
 template <typename T>
 class GFP;
 
@@ -33,7 +38,7 @@ class GF : public RN<T> {
 };
 
 template <typename T>
-GF<T>::GF(T p, int n) : RN<T>(_exp<T>(p, n))
+GF<T>::GF(T p, int n) : RN<T>(arith::_exp<T>(p, n))
 {
     // XXX shall check that p is prime
     this->p = p;
@@ -75,5 +80,8 @@ int GF<T>::get_n()
 {
     return n;
 }
+
+} // namespace gf
+} // namespace nttec
 
 #endif

--- a/src/gf.h
+++ b/src/gf.h
@@ -38,7 +38,7 @@ class GF : public RN<T> {
 };
 
 template <typename T>
-GF<T>::GF(T p, int n) : RN<T>(arith::_exp<T>(p, n))
+GF<T>::GF(T p, int n) : RN<T>(arith::exp<T>(p, n))
 {
     // XXX shall check that p is prime
     this->p = p;

--- a/src/gf2n.h
+++ b/src/gf2n.h
@@ -5,6 +5,9 @@
 #include <climits>
 #include "gf.h"
 
+namespace nttec {
+namespace gf {
+
 template <typename T>
 class GF2N : public GF<T> {
   private:
@@ -496,5 +499,8 @@ T GF2N<T>::_inv_ext_gcd(T x)
     }
     return g[a];
 }
+
+} // namespace gf
+} // namespace nttec
 
 #endif

--- a/src/gfp.h
+++ b/src/gfp.h
@@ -4,6 +4,9 @@
 
 #include "gf.h"
 
+namespace nttec {
+namespace gf {
+
 template <typename T>
 class GFP : public GF<T> {
   public:
@@ -30,5 +33,8 @@ T GFP<T>::inv_exp(T a)
 
     return this->exp(a, this->p - 2);
 }
+
+} // namespace gf
+} // namespace nttec
 
 #endif

--- a/src/gfpn.h
+++ b/src/gfpn.h
@@ -83,7 +83,7 @@ GFPN<T>::~GFPN()
 template <typename T>
 T GFPN<T>::card(void)
 {
-    return arith::_exp<T>(this->p, this->n);
+    return arith::exp<T>(this->p, this->n);
 }
 
 template <typename T>
@@ -219,7 +219,7 @@ T GFPN<T>::weak_rand(void)
 
 retry:
     for (int i = 0; i < this->n; i++)
-        _a.set(i, arith::_weak_rand0<T>(this->p));
+        _a.set(i, arith::weak_rand0<T>(this->p));
 
     num = _a.to_num();
     if (0 == num)

--- a/src/gfpn.h
+++ b/src/gfpn.h
@@ -4,8 +4,12 @@
 
 #include "gf.h"
 
+namespace nttec {
+
 template <typename T>
 class Poly;
+
+namespace gf {
 
 template <typename T>
 class GFPN : public GF<T> {
@@ -79,7 +83,7 @@ GFPN<T>::~GFPN()
 template <typename T>
 T GFPN<T>::card(void)
 {
-    return _exp<T>(this->p, this->n);
+    return arith::_exp<T>(this->p, this->n);
 }
 
 template <typename T>
@@ -215,7 +219,7 @@ T GFPN<T>::weak_rand(void)
 
 retry:
     for (int i = 0; i < this->n; i++)
-        _a.set(i, _weak_rand0<T>(this->p));
+        _a.set(i, arith::_weak_rand0<T>(this->p));
 
     num = _a.to_num();
     if (0 == num)
@@ -223,5 +227,8 @@ retry:
 
     return num;
 }
+
+} // namespace gf
+} // namespace nttec
 
 #endif

--- a/src/mat.h
+++ b/src/mat.h
@@ -6,6 +6,8 @@
 
 #include "rn.h"
 
+namespace nttec {
+
 /*
  * mat[n_rows][n_cols]:
  * mat[0][0] mat[0][1] ... mat[0][n_cols]
@@ -23,7 +25,7 @@ class Mat {
     void set(int i, int j, T val);
     virtual T get(int i, int j);
     void inv(void);
-    void mul(Vec<T>* output, Vec<T>* v);
+    void mul(vec::Vec<T>* output, vec::Vec<T>* v);
     void vandermonde(void);
     void vandermonde_suitable_for_ec(void);
     void cauchy(void);
@@ -344,7 +346,7 @@ void Mat<T>::vandermonde_suitable_for_ec(void)
 }
 
 template <typename T>
-void Mat<T>::mul(Vec<T>* output, Vec<T>* v)
+void Mat<T>::mul(vec::Vec<T>* output, vec::Vec<T>* v)
 {
     int i, j;
 
@@ -412,5 +414,7 @@ void Mat<T>::dump(void)
         std::cout << "\n";
     }
 }
+
+} // namespace nttec
 
 #endif

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -2,6 +2,8 @@
 
 #include "misc.h"
 
+namespace std {
+
 std::ostream& operator<<(std::ostream& dest, __uint128_t value)
 {
     std::ostream::sentry s(dest);
@@ -46,3 +48,5 @@ std::ostream& operator<<(std::ostream& dest, __int128_t value)
     }
     return dest;
 }
+
+} // namespace std

--- a/src/misc.h
+++ b/src/misc.h
@@ -2,6 +2,8 @@
 #ifndef __NTTEC_MISC_H__
 #define __NTTEC_MISC_H__
 
+namespace nttec {
+
 #if defined(__i386__)
 static __inline__ unsigned long long rdtsc(void)
 {
@@ -17,5 +19,7 @@ static __inline__ unsigned long long rdtsc(void)
     return ((unsigned long long)lo) | (((unsigned long long)hi) << 32);
 }
 #endif
+
+} // namespace nttec
 
 #endif

--- a/src/ngff4.h
+++ b/src/ngff4.h
@@ -8,8 +8,12 @@
 #define MASK16 0xFFFF
 #define MASK32 0xFFFFFFFF
 
+namespace nttec {
+
 template <typename T>
 class Poly;
+
+namespace gf {
 
 template <typename T>
 class NGFF4 : public GF<T> {
@@ -48,7 +52,7 @@ class NGFF4 : public GF<T> {
     T pack(T a, uint32_t flag);
     compT<T> unpack(T a);
     T get_nth_root(T n);
-    void compute_omegas(Vec<T>* W, int n, T w);
+    void compute_omegas(vec::Vec<T>* W, int n, T w);
     GF<uint32_t>* get_sub_field();
 };
 
@@ -408,7 +412,7 @@ bool NGFF4<T>::check(T a)
  * @param w n-th root of unity
  */
 template <typename T>
-void NGFF4<T>::compute_omegas(Vec<T>* W, int n, T w)
+void NGFF4<T>::compute_omegas(vec::Vec<T>* W, int n, T w)
 {
     for (int i = 0; i < n; i++) {
         W->set(i, this->exp(w, replicate(i)));
@@ -420,5 +424,8 @@ GF<uint32_t>* NGFF4<T>::get_sub_field()
 {
     return sub_field;
 }
+
+} // namespace gf
+} // namespace nttec
 
 #endif

--- a/src/nttec.h
+++ b/src/nttec.h
@@ -2,6 +2,11 @@
 #ifndef __NTTEC_NTTEC_H__
 #define __NTTEC_NTTEC_H__
 
+/** @namespace nttec
+ *
+ * The root namespace of the NTTEC library.
+ */
+
 #include "arith.h"
 #include "build_info.h"
 #include "config.h"

--- a/src/poly.h
+++ b/src/poly.h
@@ -451,7 +451,7 @@ T Poly<T>::to_num()
     T result = 0;
 
     while (i >= 0) {
-        result += get(i) * arith::_exp<T>(gf->card(), i);
+        result += get(i) * arith::exp<T>(gf->card(), i);
         i--;
     }
     return result;
@@ -467,7 +467,7 @@ void Poly<T>::from_num(T x, int max_deg)
 {
     clear(); // XXX
     for (int i = max_deg; i >= 0; i--) {
-        T tmp = arith::_exp<T>(gf->card(), i);
+        T tmp = arith::exp<T>(gf->card(), i);
         T tmp2 = x / tmp;
         if (tmp2 != 0)
             set(i, tmp2);

--- a/src/poly.h
+++ b/src/poly.h
@@ -7,20 +7,26 @@
 #include "core.h"
 #include "gf.h"
 
+namespace nttec {
+
+namespace vec {
+
 template <typename T>
 class Vec;
+
+} // namespace vec
 
 template <typename T>
 class Poly {
   private:
     struct Term : std::map<int, T> {
     };
-    GF<T>* gf;
-    GF<T>* sub_field;
+    gf::GF<T>* gf;
+    gf::GF<T>* sub_field;
     Term terms;
 
   public:
-    explicit Poly(GF<T>* gf);
+    explicit Poly(gf::GF<T>* gf);
     void clear();
     void copy(Poly<T>* src);
     void copy(Poly<T>* src, T offset);
@@ -51,7 +57,7 @@ class Poly {
     void derivative();
     T eval(T x);
     bool equal(Poly<T>* f);
-    void to_vec(Vec<T>* vec);
+    void to_vec(vec::Vec<T>* vec);
     T to_num();
     void from_num(T x, int max_deg);
     void dump(std::ostream& dest);
@@ -59,7 +65,7 @@ class Poly {
 };
 
 template <typename T>
-Poly<T>::Poly(GF<T>* gf)
+Poly<T>::Poly(gf::GF<T>* gf)
 {
     this->gf = gf;
     this->sub_field = gf->get_sub_field();
@@ -421,7 +427,7 @@ bool Poly<T>::equal(Poly<T>* f)
 }
 
 template <typename T>
-void Poly<T>::to_vec(Vec<T>* vec)
+void Poly<T>::to_vec(vec::Vec<T>* vec)
 {
     T deg = degree();
     assert(vec->get_n() > deg);
@@ -445,7 +451,7 @@ T Poly<T>::to_num()
     T result = 0;
 
     while (i >= 0) {
-        result += get(i) * _exp<T>(gf->card(), i);
+        result += get(i) * arith::_exp<T>(gf->card(), i);
         i--;
     }
     return result;
@@ -461,7 +467,7 @@ void Poly<T>::from_num(T x, int max_deg)
 {
     clear(); // XXX
     for (int i = max_deg; i >= 0; i--) {
-        T tmp = _exp<T>(gf->card(), i);
+        T tmp = arith::_exp<T>(gf->card(), i);
         T tmp2 = x / tmp;
         if (tmp2 != 0)
             set(i, tmp2);
@@ -499,5 +505,7 @@ void Poly<T>::dump()
     dump(std::cout);
     std::cout << "\n";
 }
+
+} // namespace nttec
 
 #endif

--- a/src/rn.h
+++ b/src/rn.h
@@ -201,7 +201,7 @@ T RN<T>::inv_bezout(T a)
     SignedDoubleT<T> n = this->_card;
     SignedDoubleT<T> bezout[2];
 
-    arith::_extended_gcd<T>(x, n, bezout, nullptr);
+    arith::extended_gcd<T>(x, n, bezout, nullptr);
     if (bezout[0] < 0)
         bezout[0] = this->_card + bezout[0];
     return bezout[0];
@@ -399,14 +399,14 @@ void RN<T>::compute_factors_of_order()
     T h = this->card_minus_one();
     // prime factorisation of order, i.e. order = p_i^e_i where
     //  p_i, e_i are ith element of this->primes and this->exponent
-    arith::_factor_prime<T>(h, this->primes, this->exponent);
+    arith::factor_prime<T>(h, this->primes, this->exponent);
     // store all primes in a vector. A prime is replicated according to its
     //  exponent
-    arith::_get_prime_factors_final<T>(
+    arith::get_prime_factors_final<T>(
         this->primes, this->exponent, this->all_primes_factors);
     // calculate all proper divisor of order. A proper divisor = order/p_i for
     //  each prime divisor of order.
-    arith::_get_proper_divisors<T>(h, this->primes, this->proper_divisors);
+    arith::get_proper_divisors<T>(h, this->primes, this->proper_divisors);
 
     this->compute_factors_of_order_done = true;
 }
@@ -489,7 +489,7 @@ void RN<T>::compute_omegas_cached(vec::Vec<T>* W, int n, T w)
 template <typename T>
 T RN<T>::weak_rand(void)
 {
-    return arith::_weak_rand<T>(this->card());
+    return arith::weak_rand<T>(this->card());
 }
 
 /*
@@ -648,7 +648,7 @@ T RN<T>::get_order(T x)
         return 1;
     T h = this->card_minus_one();
     if (!this->compute_factors_of_order_done)
-        arith::_factor_prime<T>(h, this->primes, this->exponent);
+        arith::factor_prime<T>(h, this->primes, this->exponent);
     std::vector<T> _primes(*primes);
     std::vector<int> _exponent(*exponent);
     T order = do_step_get_order(x, h, &_primes, &_exponent);
@@ -700,7 +700,7 @@ template <typename T>
 T RN<T>::get_nth_root(T n)
 {
     T q_minus_one = this->card_minus_one();
-    T d = arith::_gcd<T>(n, q_minus_one);
+    T d = arith::gcd<T>(n, q_minus_one);
     if (!this->root)
         this->find_prime_root();
     T nth_root = this->exp(this->root, q_minus_one / d);
@@ -736,7 +736,7 @@ T RN<T>::get_code_len(T n)
     if (nb < n)
         assert(false);
 
-    return arith::_get_code_len<T>(nb, n);
+    return arith::get_code_len<T>(nb, n);
 }
 
 /**
@@ -759,7 +759,7 @@ T RN<T>::get_code_len_high_compo(T n)
     if (!this->compute_factors_of_order_done) {
         this->compute_factors_of_order();
     }
-    return arith::_get_code_len_high_compo<T>(this->all_primes_factors, n);
+    return arith::get_code_len_high_compo<T>(this->all_primes_factors, n);
 }
 
 } // namespace nttec

--- a/src/rn.h
+++ b/src/rn.h
@@ -11,11 +11,17 @@
 #include "arith.h"
 #include "core.h"
 
+namespace nttec {
+
+namespace vec {
+
 template <typename T>
 class Vec;
 
 template <typename T>
 class Vecp;
+
+} // namespace vec
 
 /**
  * Generic class for the Ring of integers modulo N
@@ -47,15 +53,17 @@ class RN {
     T exp_quick(T base, T exponent);
     T log_naive(T base, T exponent);
     virtual void mul_coef_to_buf(T a, T* src, T* dest, size_t len);
-    virtual void mul_vec_to_vecp(Vec<T>* u, Vecp<T>* src, Vecp<T>* dest);
+    virtual void
+    mul_vec_to_vecp(vec::Vec<T>* u, vec::Vecp<T>* src, vec::Vecp<T>* dest);
     virtual void add_two_bufs(T* src, T* dest, size_t len);
-    virtual void add_vecp_to_vecp(Vecp<T>* src, Vecp<T>* dest);
+    virtual void add_vecp_to_vecp(vec::Vecp<T>* src, vec::Vecp<T>* dest);
     virtual void sub_two_bufs(T* bufa, T* bufb, T* res, size_t len);
-    virtual void sub_vecp_to_vecp(Vecp<T>* veca, Vecp<T>* vecb, Vecp<T>* res);
+    virtual void
+    sub_vecp_to_vecp(vec::Vecp<T>* veca, vec::Vecp<T>* vecb, vec::Vecp<T>* res);
     void compute_factors_of_order();
     bool is_quadratic_residue(T q);
-    virtual void compute_omegas(Vec<T>* W, int n, T w);
-    void compute_omegas_cached(Vec<T>* W, int n, T w);
+    virtual void compute_omegas(vec::Vec<T>* W, int n, T w);
+    void compute_omegas_cached(vec::Vec<T>* W, int n, T w);
     virtual T weak_rand(void);
     bool is_prime_root(T nb);
     void find_prime_root();
@@ -193,7 +201,7 @@ T RN<T>::inv_bezout(T a)
     SignedDoubleT<T> n = this->_card;
     SignedDoubleT<T> bezout[2];
 
-    _extended_gcd<T>(x, n, bezout, nullptr);
+    arith::_extended_gcd<T>(x, n, bezout, nullptr);
     if (bezout[0] < 0)
         bezout[0] = this->_card + bezout[0];
     return bezout[0];
@@ -314,7 +322,10 @@ void RN<T>::mul_coef_to_buf(T a, T* src, T* dest, size_t len)
 }
 
 template <typename T>
-void RN<T>::mul_vec_to_vecp(Vec<T>* u, Vecp<T>* src, Vecp<T>* dest)
+void RN<T>::mul_vec_to_vecp(
+    vec::Vec<T>* u,
+    vec::Vecp<T>* src,
+    vec::Vecp<T>* dest)
 {
     assert(u->get_n() == src->get_n());
     int i;
@@ -336,7 +347,7 @@ void RN<T>::add_two_bufs(T* src, T* dest, size_t len)
 }
 
 template <typename T>
-void RN<T>::add_vecp_to_vecp(Vecp<T>* src, Vecp<T>* dest)
+void RN<T>::add_vecp_to_vecp(vec::Vecp<T>* src, vec::Vecp<T>* dest)
 {
     assert(src->get_n() == dest->get_n());
     assert(src->get_size() == dest->get_size());
@@ -364,7 +375,10 @@ void RN<T>::sub_two_bufs(T* bufa, T* bufb, T* res, size_t len)
 }
 
 template <typename T>
-void RN<T>::sub_vecp_to_vecp(Vecp<T>* veca, Vecp<T>* vecb, Vecp<T>* res)
+void RN<T>::sub_vecp_to_vecp(
+    vec::Vecp<T>* veca,
+    vec::Vecp<T>* vecb,
+    vec::Vecp<T>* res)
 {
     assert(veca->get_n() == vecb->get_n());
     assert(veca->get_size() == vecb->get_size());
@@ -385,14 +399,14 @@ void RN<T>::compute_factors_of_order()
     T h = this->card_minus_one();
     // prime factorisation of order, i.e. order = p_i^e_i where
     //  p_i, e_i are ith element of this->primes and this->exponent
-    _factor_prime<T>(h, this->primes, this->exponent);
+    arith::_factor_prime<T>(h, this->primes, this->exponent);
     // store all primes in a vector. A prime is replicated according to its
     //  exponent
-    _get_prime_factors_final<T>(
+    arith::_get_prime_factors_final<T>(
         this->primes, this->exponent, this->all_primes_factors);
     // calculate all proper divisor of order. A proper divisor = order/p_i for
     //  each prime divisor of order.
-    _get_proper_divisors<T>(h, this->primes, this->proper_divisors);
+    arith::_get_proper_divisors<T>(h, this->primes, this->proper_divisors);
 
     this->compute_factors_of_order_done = true;
 }
@@ -427,7 +441,7 @@ bool RN<T>::is_quadratic_residue(T q)
  * @param w n-th root of unity
  */
 template <typename T>
-void RN<T>::compute_omegas(Vec<T>* W, int n, T w)
+void RN<T>::compute_omegas(vec::Vec<T>* W, int n, T w)
 {
     for (int i = 0; i < n; i++) {
         W->set(i, this->exp(w, i));
@@ -446,7 +460,7 @@ void RN<T>::compute_omegas(Vec<T>* W, int n, T w)
  * @param w n-th root of unity
  */
 template <typename T>
-void RN<T>::compute_omegas_cached(Vec<T>* W, int n, T w)
+void RN<T>::compute_omegas_cached(vec::Vec<T>* W, int n, T w)
 {
     std::ostringstream filename;
 
@@ -475,7 +489,7 @@ void RN<T>::compute_omegas_cached(Vec<T>* W, int n, T w)
 template <typename T>
 T RN<T>::weak_rand(void)
 {
-    return _weak_rand<T>(this->card());
+    return arith::_weak_rand<T>(this->card());
 }
 
 /*
@@ -634,7 +648,7 @@ T RN<T>::get_order(T x)
         return 1;
     T h = this->card_minus_one();
     if (!this->compute_factors_of_order_done)
-        _factor_prime<T>(h, this->primes, this->exponent);
+        arith::_factor_prime<T>(h, this->primes, this->exponent);
     std::vector<T> _primes(*primes);
     std::vector<int> _exponent(*exponent);
     T order = do_step_get_order(x, h, &_primes, &_exponent);
@@ -686,7 +700,7 @@ template <typename T>
 T RN<T>::get_nth_root(T n)
 {
     T q_minus_one = this->card_minus_one();
-    T d = _gcd<T>(n, q_minus_one);
+    T d = arith::_gcd<T>(n, q_minus_one);
     if (!this->root)
         this->find_prime_root();
     T nth_root = this->exp(this->root, q_minus_one / d);
@@ -722,7 +736,7 @@ T RN<T>::get_code_len(T n)
     if (nb < n)
         assert(false);
 
-    return _get_code_len<T>(nb, n);
+    return arith::_get_code_len<T>(nb, n);
 }
 
 /**
@@ -745,7 +759,9 @@ T RN<T>::get_code_len_high_compo(T n)
     if (!this->compute_factors_of_order_done) {
         this->compute_factors_of_order();
     }
-    return _get_code_len_high_compo<T>(this->all_primes_factors, n);
+    return arith::_get_code_len_high_compo<T>(this->all_primes_factors, n);
 }
+
+} // namespace nttec
 
 #endif

--- a/src/v2vec.h
+++ b/src/v2vec.h
@@ -5,6 +5,9 @@
 #include "rn.h"
 #include "vec.h"
 
+namespace nttec {
+namespace vec {
+
 /**
  * Virtual (v->get_n()*2) x 1 vertical vector for the need of
  * Cooley-Tukey algorithm
@@ -61,5 +64,8 @@ T V2Vec<T>::get(int i)
     else
         return vec->get(i - vec_n);
 }
+
+} // namespace vec
+} // namespace nttec
 
 #endif

--- a/src/v2vecp.h
+++ b/src/v2vecp.h
@@ -4,6 +4,9 @@
 
 #include "vecp.h"
 
+namespace nttec {
+namespace vec {
+
 /**
  * Virtual (v->get_n()*2) x 1 vertical vector for the need of
  * Cooley-Tukey algorithm
@@ -45,5 +48,8 @@ T* V2Vecp<T>::get(int i)
     else
         return vec->get(i - vec_n);
 }
+
+} // namespace vec
+} // namespace nttec
 
 #endif

--- a/src/vcvec.h
+++ b/src/vcvec.h
@@ -5,6 +5,9 @@
 #include "rn.h"
 #include "vec.h"
 
+namespace nttec {
+namespace vec {
+
 /**
  * Virtual vector on a base vector from an offset and a step
  *
@@ -85,5 +88,8 @@ void VcVec<T>::set(int i, T val)
     T loc = (offset + step * i) % this->N;
     vec->set(loc, val);
 }
+
+} // namespace vec
+} // namespace nttec
 
 #endif

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1,5 +1,8 @@
 #include "vec.h"
 
+namespace nttec {
+namespace vec {
+
 void _vec_hadamard_mul_257(int n, uint32_t* x, uint32_t* y)
 {
     int i;
@@ -207,3 +210,6 @@ void Vec<uint64_t>::add(V2Vec<uint64_t>* v)
     for (j = 0; i < n; i++, j++)
         mem[i] = rn->add(mem[i], src[j]);
 }
+
+} // namespace vec
+} // namespace nttec

--- a/src/vecp.h
+++ b/src/vecp.h
@@ -8,6 +8,9 @@
 #include <iostream>
 #include <vector>
 
+namespace nttec {
+namespace vec {
+
 /*
  * Wrapper of a vector of `n` buffers each of `size` elements of type T
  *  std::vector<T*> vec(n)
@@ -273,5 +276,8 @@ void Vecp<T>::dump(void)
     }
     std::cout << "\n)\n";
 }
+
+} // namespace vec
+} // namespace nttec
 
 #endif

--- a/src/vmvec.h
+++ b/src/vmvec.h
@@ -4,6 +4,9 @@
 
 #include "vec.h"
 
+namespace nttec {
+namespace vec {
+
 /**
  * Virtual vector on a base vector from an offset
  *  vmvec[i] = base[i + offset]
@@ -77,5 +80,8 @@ int VmVec<T>::get_offset()
 {
     return this->offset;
 }
+
+} // namespace vec
+} // namespace nttec
 
 #endif

--- a/src/vvec.h
+++ b/src/vvec.h
@@ -4,6 +4,9 @@
 
 #include "vec.h"
 
+namespace nttec {
+namespace vec {
+
 /**
  * Virtual vector that returns 0 beyond managed vector length
  */
@@ -40,5 +43,8 @@ T VVec<T>::get(int i)
 
     return (i < vec->get_n()) ? vec->get(i) : 0;
 }
+
+} // namespace vec
+} // namespace nttec
 
 #endif

--- a/src/vvecp.h
+++ b/src/vvecp.h
@@ -4,6 +4,9 @@
 
 #include "vec.h"
 
+namespace nttec {
+namespace vec {
+
 /**
  * Virtual vector that padds zero_chunk beyond managed vector length
  */
@@ -45,5 +48,8 @@ VVecp<T>::~VVecp()
     this->mem->shrink_to_fit();
     delete this->mem;
 }
+
+} // namespace vec
+} // namespace nttec
 
 #endif

--- a/test/arith_utest.cpp
+++ b/test/arith_utest.cpp
@@ -21,29 +21,29 @@ class ArithUtest {
     void test_basic_ops()
     {
         std::cout << "test_basic_ops\n";
-        assert(nttec::arith::_sqrt<T>(2025) == 45);
-        assert(nttec::arith::_is_prime<T>(2));
-        assert(nttec::arith::_is_prime<T>(3));
-        assert(nttec::arith::_is_prime<T>(13));
-        assert(!nttec::arith::_is_prime<T>(4));
-        assert(!nttec::arith::_is_prime<T>(15));
+        assert(nttec::arith::sqrt<T>(2025) == 45);
+        assert(nttec::arith::is_prime<T>(2));
+        assert(nttec::arith::is_prime<T>(3));
+        assert(nttec::arith::is_prime<T>(13));
+        assert(!nttec::arith::is_prime<T>(4));
+        assert(!nttec::arith::is_prime<T>(15));
     }
 
     void test_reciprocal()
     {
         std::cout << "test_reciprocal\n";
         int i;
-        T sub_max = nttec::arith::_sqrt<T>(max);
+        T sub_max = nttec::arith::sqrt<T>(max);
         for (i = 0; i < 1000; i++) {
             T x, y, z;
 
             // std::cout << "i=" << i << "\n";
 
-            x = nttec::arith::_weak_rand<T>(sub_max);
+            x = nttec::arith::weak_rand<T>(sub_max);
             // std::cout << "x=" << x << "\n";
-            y = nttec::arith::_exp<T>(x, 2);
+            y = nttec::arith::exp<T>(x, 2);
             // std::cout << "exp(x)=" << y << "\n";
-            z = nttec::arith::_sqrt<T>(y);
+            z = nttec::arith::sqrt<T>(y);
             // std::cout << "z=" << z << "\n";
             assert(z == x);
         }
@@ -67,33 +67,33 @@ class ArithUtest {
         n[0] = 107;
         a[1] = 2;
         n[1] = 74;
-        omega = nttec::arith::_chinese_remainder<T>(2, a, n);
+        omega = nttec::arith::chinese_remainder<T>(2, a, n);
         assert(omega == 5996);
 
         a[0] = 6;
         n[0] = 7;
         a[1] = 4;
         n[1] = 8;
-        omega = nttec::arith::_chinese_remainder<T>(2, a, n);
+        omega = nttec::arith::chinese_remainder<T>(2, a, n);
         assert(omega == 20);
 
         a[0] = 3;
         n[0] = 4;
         a[1] = 0;
         n[1] = 6;
-        omega = nttec::arith::_chinese_remainder<T>(2, a, n);
+        omega = nttec::arith::chinese_remainder<T>(2, a, n);
         // no solution XXX detect it
     }
 
     void test_jacobi()
     {
         std::cout << "test_jacobi\n";
-        assert(nttec::arith::_jacobi<T>(1001, 9907) == -1);
-        assert(nttec::arith::_jacobi<T>(19, 45) == 1);
-        assert(nttec::arith::_jacobi<T>(8, 21) == -1);
-        assert(nttec::arith::_jacobi<T>(5, 21) == 1);
-        assert(nttec::arith::_jacobi<T>(47, 221) == -1);
-        assert(nttec::arith::_jacobi<T>(2, 221) == -1);
+        assert(nttec::arith::jacobi<T>(1001, 9907) == -1);
+        assert(nttec::arith::jacobi<T>(19, 45) == 1);
+        assert(nttec::arith::jacobi<T>(8, 21) == -1);
+        assert(nttec::arith::jacobi<T>(5, 21) == 1);
+        assert(nttec::arith::jacobi<T>(47, 221) == -1);
+        assert(nttec::arith::jacobi<T>(2, 221) == -1);
     }
 
     /**
@@ -111,7 +111,7 @@ class ArithUtest {
 
         int b = 10; // base
         int p = 14; // we could multiply integers of 2^p digits
-        // T max_digits = nttec::arith::_exp<T>(2, p);
+        // T max_digits = nttec::arith::exp<T>(2, p);
         // std::cerr << "p=" << p << " max_digits=" << max_digits << "\n";
 
         // T l = p + 1;
@@ -122,11 +122,11 @@ class ArithUtest {
         // a 2^n-th principal root of unity in GF_p
         T a1 = 2;
         T a2 = 5;
-        T p1 = a1 * nttec::arith::_exp<T>(2, 15) + 1;
-        T p2 = a2 * nttec::arith::_exp<T>(2, 15) + 1;
+        T p1 = a1 * nttec::arith::exp<T>(2, 15) + 1;
+        T p2 = a2 * nttec::arith::exp<T>(2, 15) + 1;
         // std::cerr << "p1=" << p1 << " p2=" << p2 << "\n";
-        assert(nttec::arith::_is_prime<T>(p1));
-        assert(nttec::arith::_is_prime<T>(p2));
+        assert(nttec::arith::is_prime<T>(p1));
+        assert(nttec::arith::is_prime<T>(p2));
 
         // ensure their product is bounded (b-1)^2*2^(n-1) < m
         T m = p1 * p2;
@@ -134,24 +134,21 @@ class ArithUtest {
         assert(m / p1 == p2);
         // std::cerr << " m=" << m << "\n";
         assert(
-            nttec::arith::_exp<T>((b - 1), 2) * nttec::arith::_exp<T>(p, 2)
-            < m);
+            nttec::arith::exp<T>((b - 1), 2) * nttec::arith::exp<T>(p, 2) < m);
 
         // find x so it is not a quadratic residue in GF_p1 and GF_p2
         assert(
-            nttec::arith::_jacobi<T>(3, p1) == nttec::arith::_jacobi<T>(p1, 3));
+            nttec::arith::jacobi<T>(3, p1) == nttec::arith::jacobi<T>(p1, 3));
+        assert(nttec::arith::jacobi<T>(p1, 3) == nttec::arith::jacobi<T>(2, 3));
         assert(
-            nttec::arith::_jacobi<T>(p1, 3) == nttec::arith::_jacobi<T>(2, 3));
-        assert(
-            nttec::arith::_jacobi<T>(3, p2) == nttec::arith::_jacobi<T>(p2, 3));
-        assert(
-            nttec::arith::_jacobi<T>(p2, 3) == nttec::arith::_jacobi<T>(2, 3));
-        assert(nttec::arith::_jacobi<T>(2, 3) == -1);
+            nttec::arith::jacobi<T>(3, p2) == nttec::arith::jacobi<T>(p2, 3));
+        assert(nttec::arith::jacobi<T>(p2, 3) == nttec::arith::jacobi<T>(2, 3));
+        assert(nttec::arith::jacobi<T>(2, 3) == -1);
         // which means x=3 is not a quadratic residue in GF_p1 and GF_p2
 
         // therefore we can compute 2^n-th roots of unity in GF_p1 and GF_p2
-        T w1 = nttec::arith::_exp<T>(3, a1);
-        T w2 = nttec::arith::_exp<T>(3, a2);
+        T w1 = nttec::arith::exp<T>(3, a1);
+        T w2 = nttec::arith::exp<T>(3, a2);
         // std::cerr << "w1=" << w1 << " w2=" << w2 << "\n";
         assert(w1 == 9);
         assert(w2 == 243);
@@ -163,7 +160,7 @@ class ArithUtest {
         _n[0] = p1;
         _a[1] = w2;
         _n[1] = p2;
-        T w = nttec::arith::_chinese_remainder<T>(2, _a, _n);
+        T w = nttec::arith::chinese_remainder<T>(2, _a, _n);
         // std::cerr << " w=" << w << "\n";
         assert(w == 25559439);
     }
@@ -174,11 +171,11 @@ class ArithUtest {
         nttec::SignedDoubleT<T> bezout[2];
 
         // not explicitely related to GF(97)
-        assert(2 == nttec::arith::_extended_gcd<T>(240, 46, nullptr, nullptr));
-        assert(6 == nttec::arith::_extended_gcd<T>(54, 24, nullptr, nullptr));
-        assert(15 == nttec::arith::_extended_gcd<T>(210, 45, nullptr, nullptr));
+        assert(2 == nttec::arith::extended_gcd<T>(240, 46, nullptr, nullptr));
+        assert(6 == nttec::arith::extended_gcd<T>(54, 24, nullptr, nullptr));
+        assert(15 == nttec::arith::extended_gcd<T>(210, 45, nullptr, nullptr));
         //
-        assert(1 == nttec::arith::_extended_gcd<T>(97, 20, bezout, nullptr));
+        assert(1 == nttec::arith::extended_gcd<T>(97, 20, bezout, nullptr));
         assert(bezout[0] == -7 && bezout[1] == 34);
     }
 
@@ -188,11 +185,11 @@ class ArithUtest {
 
         typename std::vector<T>::size_type j;
 
-        assert(nttec::arith::_is_prime<T>(primes->at(0)));
+        assert(nttec::arith::is_prime<T>(primes->at(0)));
 
         for (j = 1; j != primes->size(); ++j) {
             // std::cout << j << ": " << primes->at(j) << "\n";
-            assert(nttec::arith::_is_prime<T>(primes->at(j)));
+            assert(nttec::arith::is_prime<T>(primes->at(j)));
             if (distinct)
                 assert(primes->at(j - 1) != primes->at(j));
         }
@@ -209,7 +206,7 @@ class ArithUtest {
         typename std::vector<int>::size_type j;
         T y = 1;
         for (j = 0; j != primes->size(); ++j) {
-            y *= nttec::arith::_exp<T>(primes->at(j), exponent->at(j));
+            y *= nttec::arith::exp<T>(primes->at(j), exponent->at(j));
         }
         assert(y == nb);
     }
@@ -223,9 +220,9 @@ class ArithUtest {
             T x;
             std::vector<T> primes;
             // std::cout << "i=" << i << "\n";
-            x = nttec::arith::_weak_rand<T>(max);
+            x = nttec::arith::weak_rand<T>(max);
             // std::cout << "x=" << x << "\n";
-            nttec::arith::_factor_distinct_prime<T>(x, &primes);
+            nttec::arith::factor_distinct_prime<T>(x, &primes);
             check_all_primes(&primes, true);
         }
     }
@@ -240,9 +237,9 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T x;
             // std::cout << "i=" << i << "\n";
-            x = nttec::arith::_weak_rand<T>(max);
+            x = nttec::arith::weak_rand<T>(max);
             // std::cout << "x=" << x << "\n";
-            nttec::arith::_factor_prime<T>(x, &primes, &exponent);
+            nttec::arith::factor_prime<T>(x, &primes, &exponent);
             check_all_primes(&primes, true);
             check_primes_exponent(x, &primes, &exponent);
             primes.clear();
@@ -252,7 +249,7 @@ class ArithUtest {
 
     void check_divisors(T nb, std::vector<T>* divisors, bool proper)
     {
-        if (proper && nttec::arith::_is_prime<T>(nb))
+        if (proper && nttec::arith::is_prime<T>(nb))
             assert(divisors->size() == 0);
         else
             assert(divisors->size() > 0);
@@ -262,7 +259,7 @@ class ArithUtest {
             // std::cout << i << ": " << divisors->at(i) << "\n";
             assert(nb % divisors->at(i) == 0);
             if (proper)
-                assert(nttec::arith::_is_prime<T>(nb / divisors->at(i)));
+                assert(nttec::arith::is_prime<T>(nb / divisors->at(i)));
         }
     }
 
@@ -275,9 +272,9 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T x;
             // std::cout << "i=" << i << "\n";
-            x = nttec::arith::_weak_rand<T>(max);
+            x = nttec::arith::weak_rand<T>(max);
             // std::cout << "x=" << x << "\n";
-            nttec::arith::_get_proper_divisors<T>(x, &divisors);
+            nttec::arith::get_proper_divisors<T>(x, &divisors);
             check_divisors(x, &divisors, true);
             divisors.clear();
         }
@@ -292,11 +289,11 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T x;
             // std::cout << "i=" << i << "\n";
-            x = nttec::arith::_weak_rand<T>(max);
+            x = nttec::arith::weak_rand<T>(max);
             std::vector<T> factors;
-            nttec::arith::_factor_distinct_prime<T>(x, &factors);
+            nttec::arith::factor_distinct_prime<T>(x, &factors);
             // std::cout << "x=" << x << "\n";
-            nttec::arith::_get_proper_divisors<T>(x, &factors, &divisors);
+            nttec::arith::get_proper_divisors<T>(x, &factors, &divisors);
             check_divisors(x, &divisors, true);
             divisors.clear();
         }
@@ -311,9 +308,9 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T x;
             // std::cout << "i=" << i << "\n";
-            x = nttec::arith::_weak_rand<T>(max);
+            x = nttec::arith::weak_rand<T>(max);
             // std::cout << "x=" << x << "\n";
-            nttec::arith::_compute_all_divisors<T>(x, &divisors);
+            nttec::arith::compute_all_divisors<T>(x, &divisors);
             check_divisors(x, &divisors, false);
             divisors.clear();
         }
@@ -327,11 +324,11 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T order, n;
             // std::cout << "i=" << i << "\n";
-            order = nttec::arith::_weak_rand<T>(max);
+            order = nttec::arith::weak_rand<T>(max);
             // std::cout << "order=" << order << "\n";
-            n = nttec::arith::_weak_rand<T>(order);
+            n = nttec::arith::weak_rand<T>(order);
             // std::cout << "n=" << n << "\n";
-            T len = nttec::arith::_get_code_len<T>(order, n);
+            T len = nttec::arith::get_code_len<T>(order, n);
             // std::cout << "len=" << len << "\n";
             assert(order % len == 0);
             assert(len >= n);
@@ -346,11 +343,11 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T order, n;
             // std::cout << "i=" << i << "\n";
-            order = nttec::arith::_weak_rand<T>(max);
+            order = nttec::arith::weak_rand<T>(max);
             // std::cout << "order=" << order << "\n";
-            n = nttec::arith::_weak_rand<T>(order);
+            n = nttec::arith::weak_rand<T>(order);
             // std::cout << "n=" << n << "\n";
-            T len = nttec::arith::_get_code_len_high_compo<T>(order, n);
+            T len = nttec::arith::get_code_len_high_compo<T>(order, n);
             // std::cout << "len=" << len << "\n";
             assert(order % len == 0);
             assert(len >= n);
@@ -365,13 +362,13 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T order, n;
             // std::cout << "i=" << i << "\n";
-            order = nttec::arith::_weak_rand<T>(max);
+            order = nttec::arith::weak_rand<T>(max);
             // std::cout << "order=" << order << "\n";
-            n = nttec::arith::_weak_rand<T>(order);
+            n = nttec::arith::weak_rand<T>(order);
             // std::cout << "n=" << n << "\n";
             std::vector<T> factors;
-            nttec::arith::_get_prime_factors<T>(order, &factors);
-            T len = nttec::arith::_get_code_len_high_compo<T>(&factors, n);
+            nttec::arith::get_prime_factors<T>(order, &factors);
+            T len = nttec::arith::get_code_len_high_compo<T>(&factors, n);
             // std::cout << "len=" << len << "\n";
             assert(order % len == 0);
             assert(len >= n);
@@ -387,7 +384,7 @@ class ArithUtest {
             // std::cout << i << ": " << divisors->at(i) << "\n";
             assert(nb % divisors->at(i) == 0);
             if (!coprime)
-                assert(nttec::arith::_is_prime<T>(divisors->at(i)));
+                assert(nttec::arith::is_prime<T>(divisors->at(i)));
             else {
                 for (j = i + 1; j != divisors->size(); ++j) {
                     assert(divisors->at(i) != divisors->at(j));
@@ -405,9 +402,9 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T n;
             // std::cout << "i=" << i << "\n";
-            n = nttec::arith::_weak_rand<T>(max);
+            n = nttec::arith::weak_rand<T>(max);
             // std::cout << "n=" << n << "\n";
-            nttec::arith::_get_coprime_factors<T>(n, &divisors);
+            nttec::arith::get_coprime_factors<T>(n, &divisors);
             check_prime_divisors(n, &divisors, true);
             divisors.clear();
         }
@@ -422,9 +419,9 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T n;
             // std::cout << "i=" << i << "\n";
-            n = nttec::arith::_weak_rand<T>(max);
+            n = nttec::arith::weak_rand<T>(max);
             // std::cout << "n=" << n << "\n";
-            nttec::arith::_get_prime_factors<T>(n, &divisors);
+            nttec::arith::get_prime_factors<T>(n, &divisors);
             check_prime_divisors(n, &divisors, false);
             divisors.clear();
         }

--- a/test/arith_utest.cpp
+++ b/test/arith_utest.cpp
@@ -21,29 +21,29 @@ class ArithUtest {
     void test_basic_ops()
     {
         std::cout << "test_basic_ops\n";
-        assert(_sqrt<T>(2025) == 45);
-        assert(_is_prime<T>(2));
-        assert(_is_prime<T>(3));
-        assert(_is_prime<T>(13));
-        assert(!_is_prime<T>(4));
-        assert(!_is_prime<T>(15));
+        assert(nttec::arith::_sqrt<T>(2025) == 45);
+        assert(nttec::arith::_is_prime<T>(2));
+        assert(nttec::arith::_is_prime<T>(3));
+        assert(nttec::arith::_is_prime<T>(13));
+        assert(!nttec::arith::_is_prime<T>(4));
+        assert(!nttec::arith::_is_prime<T>(15));
     }
 
     void test_reciprocal()
     {
         std::cout << "test_reciprocal\n";
         int i;
-        T sub_max = _sqrt<T>(max);
+        T sub_max = nttec::arith::_sqrt<T>(max);
         for (i = 0; i < 1000; i++) {
             T x, y, z;
 
             // std::cout << "i=" << i << "\n";
 
-            x = _weak_rand<T>(sub_max);
+            x = nttec::arith::_weak_rand<T>(sub_max);
             // std::cout << "x=" << x << "\n";
-            y = _exp<T>(x, 2);
+            y = nttec::arith::_exp<T>(x, 2);
             // std::cout << "exp(x)=" << y << "\n";
-            z = _sqrt<T>(y);
+            z = nttec::arith::_sqrt<T>(y);
             // std::cout << "z=" << z << "\n";
             assert(z == x);
         }
@@ -67,33 +67,33 @@ class ArithUtest {
         n[0] = 107;
         a[1] = 2;
         n[1] = 74;
-        omega = _chinese_remainder<T>(2, a, n);
+        omega = nttec::arith::_chinese_remainder<T>(2, a, n);
         assert(omega == 5996);
 
         a[0] = 6;
         n[0] = 7;
         a[1] = 4;
         n[1] = 8;
-        omega = _chinese_remainder<T>(2, a, n);
+        omega = nttec::arith::_chinese_remainder<T>(2, a, n);
         assert(omega == 20);
 
         a[0] = 3;
         n[0] = 4;
         a[1] = 0;
         n[1] = 6;
-        omega = _chinese_remainder<T>(2, a, n);
+        omega = nttec::arith::_chinese_remainder<T>(2, a, n);
         // no solution XXX detect it
     }
 
     void test_jacobi()
     {
         std::cout << "test_jacobi\n";
-        assert(_jacobi<T>(1001, 9907) == -1);
-        assert(_jacobi<T>(19, 45) == 1);
-        assert(_jacobi<T>(8, 21) == -1);
-        assert(_jacobi<T>(5, 21) == 1);
-        assert(_jacobi<T>(47, 221) == -1);
-        assert(_jacobi<T>(2, 221) == -1);
+        assert(nttec::arith::_jacobi<T>(1001, 9907) == -1);
+        assert(nttec::arith::_jacobi<T>(19, 45) == 1);
+        assert(nttec::arith::_jacobi<T>(8, 21) == -1);
+        assert(nttec::arith::_jacobi<T>(5, 21) == 1);
+        assert(nttec::arith::_jacobi<T>(47, 221) == -1);
+        assert(nttec::arith::_jacobi<T>(2, 221) == -1);
     }
 
     /**
@@ -111,7 +111,7 @@ class ArithUtest {
 
         int b = 10; // base
         int p = 14; // we could multiply integers of 2^p digits
-        // T max_digits = _exp<T>(2, p);
+        // T max_digits = nttec::arith::_exp<T>(2, p);
         // std::cerr << "p=" << p << " max_digits=" << max_digits << "\n";
 
         // T l = p + 1;
@@ -122,30 +122,36 @@ class ArithUtest {
         // a 2^n-th principal root of unity in GF_p
         T a1 = 2;
         T a2 = 5;
-        T p1 = a1 * _exp<T>(2, 15) + 1;
-        T p2 = a2 * _exp<T>(2, 15) + 1;
+        T p1 = a1 * nttec::arith::_exp<T>(2, 15) + 1;
+        T p2 = a2 * nttec::arith::_exp<T>(2, 15) + 1;
         // std::cerr << "p1=" << p1 << " p2=" << p2 << "\n";
-        assert(_is_prime<T>(p1));
-        assert(_is_prime<T>(p2));
+        assert(nttec::arith::_is_prime<T>(p1));
+        assert(nttec::arith::_is_prime<T>(p2));
 
         // ensure their product is bounded (b-1)^2*2^(n-1) < m
         T m = p1 * p2;
         // check overflow
         assert(m / p1 == p2);
         // std::cerr << " m=" << m << "\n";
-        assert(_exp<T>((b - 1), 2) * _exp<T>(p, 2) < m);
+        assert(
+            nttec::arith::_exp<T>((b - 1), 2) * nttec::arith::_exp<T>(p, 2)
+            < m);
 
         // find x so it is not a quadratic residue in GF_p1 and GF_p2
-        assert(_jacobi<T>(3, p1) == _jacobi<T>(p1, 3));
-        assert(_jacobi<T>(p1, 3) == _jacobi<T>(2, 3));
-        assert(_jacobi<T>(3, p2) == _jacobi<T>(p2, 3));
-        assert(_jacobi<T>(p2, 3) == _jacobi<T>(2, 3));
-        assert(_jacobi<T>(2, 3) == -1);
+        assert(
+            nttec::arith::_jacobi<T>(3, p1) == nttec::arith::_jacobi<T>(p1, 3));
+        assert(
+            nttec::arith::_jacobi<T>(p1, 3) == nttec::arith::_jacobi<T>(2, 3));
+        assert(
+            nttec::arith::_jacobi<T>(3, p2) == nttec::arith::_jacobi<T>(p2, 3));
+        assert(
+            nttec::arith::_jacobi<T>(p2, 3) == nttec::arith::_jacobi<T>(2, 3));
+        assert(nttec::arith::_jacobi<T>(2, 3) == -1);
         // which means x=3 is not a quadratic residue in GF_p1 and GF_p2
 
         // therefore we can compute 2^n-th roots of unity in GF_p1 and GF_p2
-        T w1 = _exp<T>(3, a1);
-        T w2 = _exp<T>(3, a2);
+        T w1 = nttec::arith::_exp<T>(3, a1);
+        T w2 = nttec::arith::_exp<T>(3, a2);
         // std::cerr << "w1=" << w1 << " w2=" << w2 << "\n";
         assert(w1 == 9);
         assert(w2 == 243);
@@ -157,7 +163,7 @@ class ArithUtest {
         _n[0] = p1;
         _a[1] = w2;
         _n[1] = p2;
-        T w = _chinese_remainder<T>(2, _a, _n);
+        T w = nttec::arith::_chinese_remainder<T>(2, _a, _n);
         // std::cerr << " w=" << w << "\n";
         assert(w == 25559439);
     }
@@ -165,14 +171,14 @@ class ArithUtest {
     void test_ext_gcd()
     {
         std::cout << "test_ext_gcd\n";
-        SignedDoubleT<T> bezout[2];
+        nttec::SignedDoubleT<T> bezout[2];
 
         // not explicitely related to GF(97)
-        assert(2 == _extended_gcd<T>(240, 46, nullptr, nullptr));
-        assert(6 == _extended_gcd<T>(54, 24, nullptr, nullptr));
-        assert(15 == _extended_gcd<T>(210, 45, nullptr, nullptr));
+        assert(2 == nttec::arith::_extended_gcd<T>(240, 46, nullptr, nullptr));
+        assert(6 == nttec::arith::_extended_gcd<T>(54, 24, nullptr, nullptr));
+        assert(15 == nttec::arith::_extended_gcd<T>(210, 45, nullptr, nullptr));
         //
-        assert(1 == _extended_gcd<T>(97, 20, bezout, nullptr));
+        assert(1 == nttec::arith::_extended_gcd<T>(97, 20, bezout, nullptr));
         assert(bezout[0] == -7 && bezout[1] == 34);
     }
 
@@ -182,11 +188,11 @@ class ArithUtest {
 
         typename std::vector<T>::size_type j;
 
-        assert(_is_prime<T>(primes->at(0)));
+        assert(nttec::arith::_is_prime<T>(primes->at(0)));
 
         for (j = 1; j != primes->size(); ++j) {
             // std::cout << j << ": " << primes->at(j) << "\n";
-            assert(_is_prime<T>(primes->at(j)));
+            assert(nttec::arith::_is_prime<T>(primes->at(j)));
             if (distinct)
                 assert(primes->at(j - 1) != primes->at(j));
         }
@@ -203,7 +209,7 @@ class ArithUtest {
         typename std::vector<int>::size_type j;
         T y = 1;
         for (j = 0; j != primes->size(); ++j) {
-            y *= _exp<T>(primes->at(j), exponent->at(j));
+            y *= nttec::arith::_exp<T>(primes->at(j), exponent->at(j));
         }
         assert(y == nb);
     }
@@ -217,9 +223,9 @@ class ArithUtest {
             T x;
             std::vector<T> primes;
             // std::cout << "i=" << i << "\n";
-            x = _weak_rand<T>(max);
+            x = nttec::arith::_weak_rand<T>(max);
             // std::cout << "x=" << x << "\n";
-            _factor_distinct_prime<T>(x, &primes);
+            nttec::arith::_factor_distinct_prime<T>(x, &primes);
             check_all_primes(&primes, true);
         }
     }
@@ -234,9 +240,9 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T x;
             // std::cout << "i=" << i << "\n";
-            x = _weak_rand<T>(max);
+            x = nttec::arith::_weak_rand<T>(max);
             // std::cout << "x=" << x << "\n";
-            _factor_prime<T>(x, &primes, &exponent);
+            nttec::arith::_factor_prime<T>(x, &primes, &exponent);
             check_all_primes(&primes, true);
             check_primes_exponent(x, &primes, &exponent);
             primes.clear();
@@ -246,7 +252,7 @@ class ArithUtest {
 
     void check_divisors(T nb, std::vector<T>* divisors, bool proper)
     {
-        if (proper && _is_prime<T>(nb))
+        if (proper && nttec::arith::_is_prime<T>(nb))
             assert(divisors->size() == 0);
         else
             assert(divisors->size() > 0);
@@ -256,7 +262,7 @@ class ArithUtest {
             // std::cout << i << ": " << divisors->at(i) << "\n";
             assert(nb % divisors->at(i) == 0);
             if (proper)
-                assert(_is_prime<T>(nb / divisors->at(i)));
+                assert(nttec::arith::_is_prime<T>(nb / divisors->at(i)));
         }
     }
 
@@ -269,9 +275,9 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T x;
             // std::cout << "i=" << i << "\n";
-            x = _weak_rand<T>(max);
+            x = nttec::arith::_weak_rand<T>(max);
             // std::cout << "x=" << x << "\n";
-            _get_proper_divisors<T>(x, &divisors);
+            nttec::arith::_get_proper_divisors<T>(x, &divisors);
             check_divisors(x, &divisors, true);
             divisors.clear();
         }
@@ -286,11 +292,11 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T x;
             // std::cout << "i=" << i << "\n";
-            x = _weak_rand<T>(max);
+            x = nttec::arith::_weak_rand<T>(max);
             std::vector<T> factors;
-            _factor_distinct_prime<T>(x, &factors);
+            nttec::arith::_factor_distinct_prime<T>(x, &factors);
             // std::cout << "x=" << x << "\n";
-            _get_proper_divisors<T>(x, &factors, &divisors);
+            nttec::arith::_get_proper_divisors<T>(x, &factors, &divisors);
             check_divisors(x, &divisors, true);
             divisors.clear();
         }
@@ -305,9 +311,9 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T x;
             // std::cout << "i=" << i << "\n";
-            x = _weak_rand<T>(max);
+            x = nttec::arith::_weak_rand<T>(max);
             // std::cout << "x=" << x << "\n";
-            _compute_all_divisors<T>(x, &divisors);
+            nttec::arith::_compute_all_divisors<T>(x, &divisors);
             check_divisors(x, &divisors, false);
             divisors.clear();
         }
@@ -321,11 +327,11 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T order, n;
             // std::cout << "i=" << i << "\n";
-            order = _weak_rand<T>(max);
+            order = nttec::arith::_weak_rand<T>(max);
             // std::cout << "order=" << order << "\n";
-            n = _weak_rand<T>(order);
+            n = nttec::arith::_weak_rand<T>(order);
             // std::cout << "n=" << n << "\n";
-            T len = _get_code_len<T>(order, n);
+            T len = nttec::arith::_get_code_len<T>(order, n);
             // std::cout << "len=" << len << "\n";
             assert(order % len == 0);
             assert(len >= n);
@@ -340,11 +346,11 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T order, n;
             // std::cout << "i=" << i << "\n";
-            order = _weak_rand<T>(max);
+            order = nttec::arith::_weak_rand<T>(max);
             // std::cout << "order=" << order << "\n";
-            n = _weak_rand<T>(order);
+            n = nttec::arith::_weak_rand<T>(order);
             // std::cout << "n=" << n << "\n";
-            T len = _get_code_len_high_compo<T>(order, n);
+            T len = nttec::arith::_get_code_len_high_compo<T>(order, n);
             // std::cout << "len=" << len << "\n";
             assert(order % len == 0);
             assert(len >= n);
@@ -359,13 +365,13 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T order, n;
             // std::cout << "i=" << i << "\n";
-            order = _weak_rand<T>(max);
+            order = nttec::arith::_weak_rand<T>(max);
             // std::cout << "order=" << order << "\n";
-            n = _weak_rand<T>(order);
+            n = nttec::arith::_weak_rand<T>(order);
             // std::cout << "n=" << n << "\n";
             std::vector<T> factors;
-            _get_prime_factors<T>(order, &factors);
-            T len = _get_code_len_high_compo<T>(&factors, n);
+            nttec::arith::_get_prime_factors<T>(order, &factors);
+            T len = nttec::arith::_get_code_len_high_compo<T>(&factors, n);
             // std::cout << "len=" << len << "\n";
             assert(order % len == 0);
             assert(len >= n);
@@ -381,7 +387,7 @@ class ArithUtest {
             // std::cout << i << ": " << divisors->at(i) << "\n";
             assert(nb % divisors->at(i) == 0);
             if (!coprime)
-                assert(_is_prime<T>(divisors->at(i)));
+                assert(nttec::arith::_is_prime<T>(divisors->at(i)));
             else {
                 for (j = i + 1; j != divisors->size(); ++j) {
                     assert(divisors->at(i) != divisors->at(j));
@@ -399,9 +405,9 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T n;
             // std::cout << "i=" << i << "\n";
-            n = _weak_rand<T>(max);
+            n = nttec::arith::_weak_rand<T>(max);
             // std::cout << "n=" << n << "\n";
-            _get_coprime_factors<T>(n, &divisors);
+            nttec::arith::_get_coprime_factors<T>(n, &divisors);
             check_prime_divisors(n, &divisors, true);
             divisors.clear();
         }
@@ -416,9 +422,9 @@ class ArithUtest {
         for (i = 0; i < 1000; i++) {
             T n;
             // std::cout << "i=" << i << "\n";
-            n = _weak_rand<T>(max);
+            n = nttec::arith::_weak_rand<T>(max);
             // std::cout << "n=" << n << "\n";
-            _get_prime_factors<T>(n, &divisors);
+            nttec::arith::_get_prime_factors<T>(n, &divisors);
             check_prime_divisors(n, &divisors, false);
             divisors.clear();
         }

--- a/test/fec_utest.cpp
+++ b/test/fec_utest.cpp
@@ -9,7 +9,7 @@ class FECUtest {
         unsigned n_data = 3;
         unsigned n_parities = 3;
 
-        FECFNTRS<T> fec = FECFNTRS<T>(2, n_data, n_parities);
+        nttec::fec::FECFNTRS<T> fec(2, n_data, n_parities);
         run_test(&fec, fec.n, n_data, n_data + n_parities, true);
     }
 
@@ -19,10 +19,10 @@ class FECUtest {
         unsigned n_data = 3;
         unsigned n_parities = 3;
 
-        for (int i = 1; i < _log2<T>(sizeof(T)); i++) {
+        for (int i = 1; i < nttec::arith::_log2<T>(sizeof(T)); i++) {
             unsigned word_size = 1 << i;
             std::cout << "test_fecngff4rs with word_size=" << word_size << "\n";
-            FECNGFF4RS<T> fec = FECNGFF4RS<T>(word_size, n_data, n_parities);
+            nttec::fec::FECNGFF4RS<T> fec(word_size, n_data, n_parities);
             run_test(&fec, fec.n, n_data, n_data + n_parities, true);
         }
     }
@@ -40,7 +40,7 @@ class FECUtest {
         unsigned n_data = 3;
         unsigned n_parities = 3;
 
-        FECGF2NFFTRS<T> fec = FECGF2NFFTRS<T>(wordsize, n_data, n_parities);
+        nttec::fec::FECGF2NFFTRS<T> fec(wordsize, n_data, n_parities);
         run_test(&fec, fec.n, n_data, n_data + n_parities);
     }
 
@@ -58,8 +58,7 @@ class FECUtest {
         unsigned n_data = 3;
         unsigned n_parities = 3;
 
-        FECGF2NFFTADDRS<T> fec =
-            FECGF2NFFTADDRS<T>(wordsize, n_data, n_parities);
+        nttec::fec::FECGF2NFFTADDRS<T> fec(wordsize, n_data, n_parities);
         run_test(&fec, fec.n, n_data, n_data + n_parities);
     }
 
@@ -77,30 +76,33 @@ class FECUtest {
         unsigned n_data = 3;
         unsigned n_parities = 3;
 
-        FECGFPFFTRS<T> fec = FECGFPFFTRS<T>(word_size, n_data, n_parities);
+        nttec::fec::FECGFPFFTRS<T> fec(word_size, n_data, n_parities);
         run_test(&fec, fec.n, n_data, n_data + n_parities, true);
     }
 
     void run_test(
-        FEC<T>* fec,
+        nttec::fec::FEC<T>* fec,
         int n,
         int n_data,
         int code_len,
         bool propos_flag = false)
     {
-        GF<T>* gf = fec->get_gf();
+        nttec::gf::GF<T>* gf = fec->get_gf();
 
-        Vec<T> v(gf, n_data), _v(gf, n), _v2(gf, n_data), f(gf, n_data),
-            v2(gf, n_data);
-        Vec<T> v_p(gf, n_data);
+        nttec::vec::Vec<T> v(gf, n_data);
+        nttec::vec::Vec<T> _v(gf, n);
+        nttec::vec::Vec<T> _v2(gf, n_data);
+        nttec::vec::Vec<T> f(gf, n_data);
+        nttec::vec::Vec<T> v2(gf, n_data);
+        nttec::vec::Vec<T> v_p(gf, n_data);
         std::vector<int> ids;
         for (int i = 0; i < code_len; i++)
             ids.push_back(i);
-        std::vector<KeyValue*> props(code_len, nullptr);
+        std::vector<nttec::KeyValue*> props(code_len, nullptr);
         for (int j = 0; j < 1000; j++) {
             if (propos_flag) {
                 for (int i = 0; i < code_len; i++)
-                    props[i] = new KeyValue();
+                    props[i] = new nttec::KeyValue();
             }
             for (int i = 0; i < n_data; i++)
                 v.set(i, gf->weak_rand());
@@ -135,46 +137,6 @@ class FECUtest {
         test_fecgfpfftrs();
     }
 };
-
-template class Mat<uint32_t>;
-template class Vec<uint32_t>;
-template class FEC<uint32_t>;
-template class FECGF2NRS<uint32_t>;
-template class FECFNTRS<uint32_t>;
-template class FECNGFF4RS<uint32_t>;
-template class FECGF2NFFTRS<uint32_t>;
-
-template class Mat<uint64_t>;
-template class Vec<uint64_t>;
-template class FEC<uint64_t>;
-template class FECGF2NRS<uint64_t>;
-template class FECFNTRS<uint64_t>;
-template class FECNGFF4RS<uint64_t>;
-template class FECGF2NFFTRS<uint64_t>;
-template class FECGFPFFTRS<uint64_t>;
-
-template class Mat<__uint128_t>;
-template class Vec<__uint128_t>;
-template class FEC<__uint128_t>;
-template class FECGF2NRS<__uint128_t>;
-// template class FECFNTRS<uint64_t>;
-template class FECNGFF4RS<__uint128_t>;
-template class FECGF2NFFTRS<__uint128_t>;
-template class FECGFPFFTRS<__uint128_t>;
-
-template class Mat<mpz_class>;
-template class Vec<mpz_class>;
-
-template class GF<uint32_t>;
-template class GFP<uint32_t>;
-template class GF2N<uint32_t>;
-
-template class GF<uint64_t>;
-template class GFP<uint64_t>;
-template class GF2N<uint64_t>;
-
-template class GF<mpz_class>;
-template class GFP<mpz_class>;
 
 void fec_utest()
 {

--- a/test/fec_utest.cpp
+++ b/test/fec_utest.cpp
@@ -19,7 +19,7 @@ class FECUtest {
         unsigned n_data = 3;
         unsigned n_parities = 3;
 
-        for (int i = 1; i < nttec::arith::_log2<T>(sizeof(T)); i++) {
+        for (int i = 1; i < nttec::arith::log2<T>(sizeof(T)); i++) {
             unsigned word_size = 1 << i;
             std::cout << "test_fecngff4rs with word_size=" << word_size << "\n";
             nttec::fec::FECNGFF4RS<T> fec(word_size, n_data, n_parities);

--- a/test/fft_utest.cpp
+++ b/test/fft_utest.cpp
@@ -3,16 +3,16 @@
 template <typename T>
 class FFTUtest {
   public:
-    void test_gcd1(GF<T>* gf)
+    void test_gcd1(nttec::gf::GF<T>* gf)
     {
-        SignedDoubleT<T> bezout[2];
+        nttec::SignedDoubleT<T> bezout[2];
 
         assert(gf->inv(20) == 34);
         //
         int i;
         for (i = 0; i < 100; i++) {
             T x = gf->weak_rand();
-            assert(1 == _extended_gcd<T>(97, x, bezout, nullptr));
+            assert(1 == nttec::arith::_extended_gcd<T>(97, x, bezout, nullptr));
             // std::cerr << bezout[0] << "*" << 97 << " " << bezout[1] << "*";
             // stdd:cerr << x << "=1\n";
             T y = gf->inv(x);
@@ -27,7 +27,7 @@ class FFTUtest {
     {
         std::cout << "test_gcd\n";
 
-        GFP<T> gf(97);
+        nttec::gf::GFP<T> gf(97);
         test_gcd1(&gf);
     }
 
@@ -35,17 +35,17 @@ class FFTUtest {
     {
         std::cout << "test_quadratic_residues\n";
 
-        GFP<T> gf32(32);
+        nttec::gf::GFP<T> gf32(32);
         int i;
         for (i = 0; i < 32; i++) {
             assert(gf32.is_quadratic_residue(gf32.exp(i, 2)));
         }
 
-        GFP<T> gf7(7);
+        nttec::gf::GFP<T> gf7(7);
         assert(gf7.is_quadratic_residue(2));
         assert(!gf7.is_quadratic_residue(5));
 
-        GFP<T> gf8(8);
+        nttec::gf::GFP<T> gf8(8);
         assert(gf8.is_quadratic_residue(1));
         assert(!gf8.is_quadratic_residue(3));
     }
@@ -57,10 +57,11 @@ class FFTUtest {
      *
      * @return
      */
-    Vec<T>* _convert_string2vec(GF<T>* gf, int n, char num[])
+    nttec::vec::Vec<T>*
+    _convert_string2vec(nttec::gf::GF<T>* gf, int n, char num[])
     {
         int i;
-        Vec<T>* vec = new Vec<T>(gf, n);
+        nttec::vec::Vec<T>* vec = new nttec::vec::Vec<T>(gf, n);
         int len = strlen(num);
 
         for (i = 0; i < len; i++) {
@@ -87,7 +88,7 @@ class FFTUtest {
 
         int b = 10; // base
         int p = 14; // we could multiply integers of 2^p digits
-        // int max_digits = _exp<T>(2, p);
+        // int max_digits = nttec::arith::_exp<T>(2, p);
         // std::cerr << "p=" << p << " max_digits=" << max_digits << "\n";
 
         uint64_t l = p + 1;
@@ -98,30 +99,36 @@ class FFTUtest {
         // a 2^n-th principal root of unity in GF_p
         uint64_t a1 = 2;
         uint64_t a2 = 5;
-        uint64_t p1 = a1 * _exp<T>(2, 15) + 1;
-        uint64_t p2 = a2 * _exp<T>(2, 15) + 1;
+        uint64_t p1 = a1 * nttec::arith::_exp<T>(2, 15) + 1;
+        uint64_t p2 = a2 * nttec::arith::_exp<T>(2, 15) + 1;
         // std::cerr << "p1=" << p1 << " p2=" << p2 << "\n";
-        assert(_is_prime<T>(p1));
-        assert(_is_prime<T>(p2));
+        assert(nttec::arith::_is_prime<T>(p1));
+        assert(nttec::arith::_is_prime<T>(p2));
 
         // ensure their product is bounded (b-1)^2*2^(n-1) < m
         uint64_t m = p1 * p2;
         // check overflow
         assert(m / p1 == p2);
         // std::cerr << " m=" << m << "\n";
-        assert(_exp<T>((b - 1), 2) * _exp<T>(p, 2) < m);
+        assert(
+            nttec::arith::_exp<T>((b - 1), 2) * nttec::arith::_exp<T>(p, 2)
+            < m);
 
         // find x so it is not a quadratic residue in GF_p1 and GF_p2
-        assert(_jacobi<T>(3, p1) == _jacobi<T>(p1, 3));
-        assert(_jacobi<T>(p1, 3) == _jacobi<T>(2, 3));
-        assert(_jacobi<T>(3, p2) == _jacobi<T>(p2, 3));
-        assert(_jacobi<T>(p2, 3) == _jacobi<T>(2, 3));
-        assert(_jacobi<T>(2, 3) == -1);
+        assert(
+            nttec::arith::_jacobi<T>(3, p1) == nttec::arith::_jacobi<T>(p1, 3));
+        assert(
+            nttec::arith::_jacobi<T>(p1, 3) == nttec::arith::_jacobi<T>(2, 3));
+        assert(
+            nttec::arith::_jacobi<T>(3, p2) == nttec::arith::_jacobi<T>(p2, 3));
+        assert(
+            nttec::arith::_jacobi<T>(p2, 3) == nttec::arith::_jacobi<T>(2, 3));
+        assert(nttec::arith::_jacobi<T>(2, 3) == -1);
         // which means x=3 is not a quadratic residue in GF_p1 and GF_p2
 
         // therefore we can compute 2^n-th roots of unity in GF_p1 and GF_p2
-        uint64_t w1 = _exp<T>(3, a1);
-        uint64_t w2 = _exp<T>(3, a2);
+        uint64_t w1 = nttec::arith::_exp<T>(3, a1);
+        uint64_t w2 = nttec::arith::_exp<T>(3, a2);
         // std::cerr << "w1=" << w1 << " w2=" << w2 << "\n";
         assert(w1 == 9);
         assert(w2 == 243);
@@ -133,32 +140,33 @@ class FFTUtest {
         _n[0] = p1;
         _a[1] = w2;
         _n[1] = p2;
-        uint64_t w = _chinese_remainder<uint64_t>(2, _a, _n);
+        uint64_t w = nttec::arith::_chinese_remainder<uint64_t>(2, _a, _n);
         // std::cerr << " w=" << w << "\n";
         assert(w == 25559439);
 
-        GFP<T> gf_m(m);
-        FFTLN<T> fft(&gf_m, l, 25559439);
+        nttec::gf::GFP<T> gf_m(m);
+        nttec::fft::FFTLN<T> fft(&gf_m, l, 25559439);
 
         // parse the big numbers
         char X[] = "1236548787985654354598651354984132468";
         char Y[] = "745211515185321545554545854598651354984132468";
 
-        Vec<T>* _X = _convert_string2vec(&gf_m, fft.get_n(), X);
+        nttec::vec::Vec<T>* _X = _convert_string2vec(&gf_m, fft.get_n(), X);
         // _X->dump();
-        Vec<T>* _Y = _convert_string2vec(&gf_m, fft.get_n(), Y);
+        nttec::vec::Vec<T>* _Y = _convert_string2vec(&gf_m, fft.get_n(), Y);
         // _Y->dump();
 
-        Vec<T>* sfX = new Vec<T>(&gf_m, fft.get_n());
-        Vec<T>* sfY = new Vec<T>(&gf_m, fft.get_n());
-        Vec<T>* _XY = new Vec<T>(&gf_m, fft.get_n());
-        Vec<T>* sfXY = new Vec<T>(&gf_m, fft.get_n());
+        nttec::vec::Vec<T>* sfX = new nttec::vec::Vec<T>(&gf_m, fft.get_n());
+        nttec::vec::Vec<T>* sfY = new nttec::vec::Vec<T>(&gf_m, fft.get_n());
+        nttec::vec::Vec<T>* _XY = new nttec::vec::Vec<T>(&gf_m, fft.get_n());
+        nttec::vec::Vec<T>* sfXY = new nttec::vec::Vec<T>(&gf_m, fft.get_n());
 
         fft.fft(sfX, _X);
         fft.fft(sfY, _Y);
 
         for (int i = 0; i <= fft.get_n() - 1; i++) {
-            DoubleT<T> val = DoubleT<T>(sfX->get(i)) * sfY->get(i);
+            nttec::DoubleT<T> val =
+                nttec::DoubleT<T>(sfX->get(i)) * sfY->get(i);
             _XY->set(i, val % m);
         }
 
@@ -194,14 +202,14 @@ class FFTUtest {
         unsigned n;
         unsigned r;
         T q = 65537;
-        GFP<T> gf = GFP<T>(q);
+        nttec::gf::GFP<T> gf(q);
         unsigned R = gf.get_prime_root(); // primitive root
         unsigned n_data = 3;
         unsigned n_parities = 3;
 
         std::cout << "test_fftn\n";
 
-        assert(_jacobi<T>(R, q) == -1);
+        assert(nttec::arith::_jacobi<T>(R, q) == -1);
 
         // with this encoder we cannot exactly satisfy users request, we need to
         // pad n = minimal divisor of (q-1) that is at least (n_parities +
@@ -214,9 +222,11 @@ class FFTUtest {
         // std::cerr << "n=" << n << "\n";
         // std::cerr << "r=" << r << "\n";
 
-        DFTN<T> fft = DFTN<T>(&gf, n, r);
+        nttec::fft::DFTN<T> fft(&gf, n, r);
 
-        Vec<T> v(&gf, fft.get_n()), _v(&gf, fft.get_n()), v2(&gf, fft.get_n());
+        nttec::vec::Vec<T> v(&gf, fft.get_n());
+        nttec::vec::Vec<T> _v(&gf, fft.get_n());
+        nttec::vec::Vec<T> v2(&gf, fft.get_n());
         for (int j = 0; j < 100000; j++) {
             v.zero_fill();
             for (unsigned i = 0; i < n_data; i++)
@@ -241,14 +251,14 @@ class FFTUtest {
     {
         unsigned n;
         unsigned q = 65537;
-        GFP<T> gf = GFP<T>(q);
+        nttec::gf::GFP<T> gf(q);
         unsigned R = gf.get_prime_root(); // primitive root
         unsigned n_data = 3;
         unsigned n_parities = 3;
 
         std::cout << "test_fft2k_vec\n";
 
-        assert(_jacobi<T>(R, q) == -1);
+        assert(nttec::arith::_jacobi<T>(R, q) == -1);
 
         // with this encoder we cannot exactly satisfy users request, we need to
         // pad n = minimal divisor of (q-1) that is at least (n_parities +
@@ -257,9 +267,11 @@ class FFTUtest {
 
         // std::cerr << "n=" << n << "\n";
 
-        FFT2K<T> fft = FFT2K<T>(&gf, n);
+        nttec::fft::FFT2K<T> fft(&gf, n);
 
-        Vec<T> v(&gf, fft.get_n()), _v(&gf, fft.get_n()), v2(&gf, fft.get_n());
+        nttec::vec::Vec<T> v(&gf, fft.get_n());
+        nttec::vec::Vec<T> _v(&gf, fft.get_n());
+        nttec::vec::Vec<T> v2(&gf, fft.get_n());
         for (int j = 0; j < 100000; j++) {
             v.zero_fill();
             for (unsigned i = 0; i < n_data; i++)
@@ -277,7 +289,7 @@ class FFTUtest {
     {
         unsigned n;
         unsigned q = 65537;
-        GFP<T> gf = GFP<T>(q);
+        nttec::gf::GFP<T> gf(q);
         unsigned R = gf.get_prime_root(); // primitive root
         unsigned n_data = 3;
         unsigned n_parities = 3;
@@ -285,7 +297,7 @@ class FFTUtest {
 
         std::cout << "test_fft2k_vecp\n";
 
-        assert(_jacobi<T>(R, q) == -1);
+        assert(nttec::arith::_jacobi<T>(R, q) == -1);
 
         // with this encoder we cannot exactly satisfy users request, we need to
         // pad n = minimal divisor of (q-1) that is at least (n_parities +
@@ -294,12 +306,14 @@ class FFTUtest {
 
         // std::cerr << "n=" << n << "\n";
 
-        FFT2K<T> fft = FFT2K<T>(&gf, n);
+        nttec::fft::FFT2K<T> fft(&gf, n);
 
         int vec_n = fft.get_n();
 
-        Vecp<T> v(n_data, size), v2(vec_n, size), _v2(vec_n, size);
-        VVecp<T> _v(&v, vec_n);
+        nttec::vec::Vecp<T> v(n_data, size);
+        nttec::vec::Vecp<T> v2(vec_n, size);
+        nttec::vec::Vecp<T> _v2(vec_n, size);
+        nttec::vec::VVecp<T> _v(&v, vec_n);
         for (int j = 0; j < 100000; j++) {
             for (unsigned i = 0; i < n_data; i++) {
                 T* mem = v.get(i);
@@ -319,7 +333,7 @@ class FFTUtest {
     void test_fftpf()
     {
         T n;
-        GF2N<T> gf = GF2N<T>(4);
+        nttec::gf::GF2N<T> gf(4);
         T n_data = 3;
         T n_parities = 3;
 
@@ -332,9 +346,11 @@ class FFTUtest {
 
         // std::cerr << "n=" << n << "\n";
 
-        FFTPF<T> fft = FFTPF<T>(&gf, n);
+        nttec::fft::FFTPF<T> fft(&gf, n);
 
-        Vec<T> v(&gf, fft.get_n()), _v(&gf, fft.get_n()), v2(&gf, fft.get_n());
+        nttec::vec::Vec<T> v(&gf, fft.get_n());
+        nttec::vec::Vec<T> _v(&gf, fft.get_n());
+        nttec::vec::Vec<T> v2(&gf, fft.get_n());
         for (int j = 0; j < 10000; j++) {
             v.zero_fill();
             for (T i = 0; i < n_data; i++)
@@ -352,7 +368,7 @@ class FFTUtest {
     {
         T n;
         T q = 65537;
-        GFP<T> gf = GFP<T>(q);
+        nttec::gf::GFP<T> gf(q);
         T n_data = 3;
         T n_parities = 3;
 
@@ -365,9 +381,11 @@ class FFTUtest {
 
         // std::cerr << "n=" << n << "\n";
 
-        FFTCT<T> fft = FFTCT<T>(&gf, n);
+        nttec::fft::FFTCT<T> fft(&gf, n);
 
-        Vec<T> v(&gf, fft.get_n()), _v(&gf, fft.get_n()), v2(&gf, fft.get_n());
+        nttec::vec::Vec<T> v(&gf, fft.get_n());
+        nttec::vec::Vec<T> _v(&gf, fft.get_n());
+        nttec::vec::Vec<T> v2(&gf, fft.get_n());
         for (int j = 0; j < 10000; j++) {
             v.zero_fill();
             for (T i = 0; i < n_data; i++)
@@ -387,7 +405,7 @@ class FFTUtest {
         T n_data = 3;
         T n_parities = 3;
         for (size_t gf_n = 4; gf_n <= 128 && gf_n <= 8 * sizeof(T); gf_n *= 2) {
-            GF2N<T> gf = GF2N<T>(gf_n);
+            nttec::gf::GF2N<T> gf(gf_n);
 
             std::cout << "test_fftct_gf2n=" << gf_n << "\n";
 
@@ -398,9 +416,9 @@ class FFTUtest {
 
             // std::cerr << "n=" << n << "\n";
 
-            FFTCT<T> fft = FFTCT<T>(&gf, n);
+            nttec::fft::FFTCT<T> fft(&gf, n);
 
-            Vec<T> v(&gf, fft.get_n()), _v(&gf, fft.get_n()),
+            nttec::vec::Vec<T> v(&gf, fft.get_n()), _v(&gf, fft.get_n()),
                 v2(&gf, fft.get_n());
             for (int j = 0; j < 10000; j++) {
                 v.zero_fill();
@@ -416,60 +434,65 @@ class FFTUtest {
         }
     }
 
-    void run_taylor_expand(GF<T>* gf, FFTADD<T>* fft)
+    void run_taylor_expand(nttec::gf::GF<T>* gf, nttec::fft::FFTADD<T>* fft)
     {
         int t = 2 + gf->weak_rand() % (fft->get_n() - 2);
         int n = t + 1 + gf->weak_rand() % (fft->get_n() - t);
-        Vec<T> v1(gf, n);
+        nttec::vec::Vec<T> v1(gf, n);
         int m = n / t;
         while (m * t < n)
             m++;
-        Vec<T> v2(gf, t * m);
+        nttec::vec::Vec<T> v2(gf, t * m);
         for (int i = 0; i < n; i++)
             v1.set(i, gf->weak_rand());
         // v1.dump();
         fft->taylor_expand(&v2, &v1, n, t);
-        Vec<T> _v1(gf, n);
+        nttec::vec::Vec<T> _v1(gf, n);
         fft->inv_taylor_expand(&_v1, &v2, t);
         // _v1.dump();
         assert(_v1.eq(&v1));
     }
 
     // taylor expansion on (x^t - x)
-    void test_taylor_expand(GF<T>* gf, FFTADD<T>* fft)
+    void test_taylor_expand(nttec::gf::GF<T>* gf, nttec::fft::FFTADD<T>* fft)
     {
         std::cout << "test_taylor_expand\n";
         for (int i = 0; i < 1000; i++)
             run_taylor_expand(gf, fft);
     }
 
-    void run_taylor_expand_t2(GF<T>* gf, FFTADD<T>* fft)
+    void run_taylor_expand_t2(nttec::gf::GF<T>* gf, nttec::fft::FFTADD<T>* fft)
     {
         int n = fft->get_n();
-        Vec<T> v1(gf, n);
+        nttec::vec::Vec<T> v1(gf, n);
         for (int i = 0; i < n; i++)
             v1.set(i, gf->weak_rand());
         // v1.dump();
         fft->taylor_expand_t2(&v1, n, true);
         // v1.dump();
-        Vec<T> _v1(gf, n);
+        nttec::vec::Vec<T> _v1(gf, n);
         fft->inv_taylor_expand_t2(&_v1);
         // _v1.dump();
         assert(_v1.eq(&v1));
     }
 
     // taylor expansion on (x^2 - x)
-    void test_taylor_expand_t2(GF<T>* gf, FFTADD<T>* fft)
+    void test_taylor_expand_t2(nttec::gf::GF<T>* gf, nttec::fft::FFTADD<T>* fft)
     {
         std::cout << "test_taylor_expand_t2\n";
         for (int i = 0; i < 1000; i++)
             run_taylor_expand_t2(gf, fft);
     }
 
-    void test_fftadd_codec(GF<T>* gf, FFTADD<T>* fft, int n_data)
+    void test_fftadd_codec(
+        nttec::gf::GF<T>* gf,
+        nttec::fft::FFTADD<T>* fft,
+        int n_data)
     {
         std::cout << "test_fftadd_codec\n";
-        Vec<T> v(gf, fft->get_n()), _v(gf, fft->get_n()), v2(gf, fft->get_n());
+        nttec::vec::Vec<T> v(gf, fft->get_n());
+        nttec::vec::Vec<T> _v(gf, fft->get_n());
+        nttec::vec::Vec<T> v2(gf, fft->get_n());
         for (int j = 0; j < 10000; j++) {
             v.zero_fill();
             for (int i = 0; i < n_data; i++)
@@ -489,14 +512,14 @@ class FFTUtest {
         int n_data = 3;
         int n_parities = 3;
         for (size_t gf_n = 4; gf_n <= 128 && gf_n <= 8 * sizeof(T); gf_n *= 2) {
-            GF2N<T> gf = GF2N<T>(gf_n);
+            nttec::gf::GF2N<T> gf(gf_n);
             std::cout << "test_fftadd_with_n=" << gf_n << "\n";
             // n is power of 2 and at least n_data + n_parities
-            n = _get_smallest_power_of_2<T>(n_data + n_parities);
-            m = _log2<T>(n);
+            n = nttec::arith::_get_smallest_power_of_2<T>(n_data + n_parities);
+            m = nttec::arith::_log2<T>(n);
 
             // std::cerr << "n=" << n << "\n";
-            FFTADD<T> fft = FFTADD<T>(&gf, m);
+            nttec::fft::FFTADD<T> fft(&gf, m);
 
             test_taylor_expand(&gf, &fft);
             test_taylor_expand_t2(&gf, &fft);
@@ -506,7 +529,7 @@ class FFTUtest {
 
     void test_fft2_gfp()
     {
-        GFP<T> gf = GFP<T>(3);
+        nttec::gf::GFP<T> gf(3);
         T n_data = 1;
 
         std::cout << "test_fft2_gfp\n";
@@ -517,9 +540,11 @@ class FFTUtest {
 
         // std::cerr << "n=" << n << "\n";
 
-        FFT2<T> fft = FFT2<T>(&gf);
+        nttec::fft::FFT2<T> fft(&gf);
 
-        Vec<T> v(&gf, fft.get_n()), _v(&gf, fft.get_n()), v2(&gf, fft.get_n());
+        nttec::vec::Vec<T> v(&gf, fft.get_n());
+        nttec::vec::Vec<T> _v(&gf, fft.get_n());
+        nttec::vec::Vec<T> v2(&gf, fft.get_n());
         for (int j = 0; j < 100000; j++) {
             v.zero_fill();
             for (T i = 0; i < n_data; i++)
@@ -538,14 +563,14 @@ class FFTUtest {
         unsigned n;
         unsigned r;
         unsigned q = 65537;
-        GFP<T> gf = GFP<T>(q);
+        nttec::gf::GFP<T> gf(q);
         unsigned R = gf.get_prime_root(); // primitive root
         unsigned n_data = 3;
         unsigned n_parities = 3;
 
         std::cout << "test_fft2\n";
 
-        assert(_jacobi<T>(R, q) == -1);
+        assert(nttec::arith::_jacobi<T>(R, q) == -1);
 
         // with this encoder we cannot exactly satisfy users request, we need to
         // pad n = minimal divisor of (q-1) that is at least (n_parities +
@@ -557,9 +582,11 @@ class FFTUtest {
 
         // std::cerr << "r=" << r << "\n";
 
-        DFTN<T> fft = DFTN<T>(&gf, n, r);
+        nttec::fft::DFTN<T> fft(&gf, n, r);
 
-        Vec<T> v(&gf, fft.get_n()), _v(&gf, fft.get_n()), v2(&gf, fft.get_n());
+        nttec::vec::Vec<T> v(&gf, fft.get_n());
+        nttec::vec::Vec<T> _v(&gf, fft.get_n());
+        nttec::vec::Vec<T> v2(&gf, fft.get_n());
         v.zero_fill();
         for (T i = 0; i < n_data; i++)
             v.set(i, gf.weak_rand());
@@ -591,7 +618,7 @@ class FFTUtest {
     void test_fft_gf2n_with_n(int n)
     {
         T r;
-        GF2N<T> gf = GF2N<T>(n);
+        nttec::gf::GF2N<T> gf(n);
         T R = gf.get_prime_root();
         T n_data = 3;
         T n_parities = 3;
@@ -610,9 +637,11 @@ class FFTUtest {
         // std::cerr << "n=" << n << "\n";
         // std::cerr << "r=" << r << "\n";
 
-        DFTN<T> fft = DFTN<T>(&gf, n, r);
+        nttec::fft::DFTN<T> fft(&gf, n, r);
 
-        Vec<T> v(&gf, fft.get_n()), _v(&gf, fft.get_n()), v2(&gf, fft.get_n());
+        nttec::vec::Vec<T> v(&gf, fft.get_n());
+        nttec::vec::Vec<T> _v(&gf, fft.get_n());
+        nttec::vec::Vec<T> v2(&gf, fft.get_n());
         for (T i = 0; i < 100000; i++) {
             v.zero_fill();
             for (T i = 0; i < n_data; i++)
@@ -652,33 +681,6 @@ class FFTUtest {
         test_mul_bignum();
     }
 };
-
-template class Mat<uint32_t>;
-template class Vec<uint32_t>;
-template class DFT<uint32_t>;
-template class FFTLN<uint32_t>;
-template class FFTPF<uint32_t>;
-template class FFTADD<uint32_t>;
-
-template class Mat<uint64_t>;
-template class Vec<uint64_t>;
-template class DFT<uint64_t>;
-template class FFTPF<uint64_t>;
-template class FFTADD<uint64_t>;
-
-template class Mat<mpz_class>;
-template class Vec<mpz_class>;
-
-template class GF<uint32_t>;
-template class GFP<uint32_t>;
-template class GF2N<uint32_t>;
-
-template class GF<uint64_t>;
-template class GFP<uint64_t>;
-template class GF2N<uint64_t>;
-
-template class GF<mpz_class>;
-template class GFP<mpz_class>;
 
 void fft_utest()
 {

--- a/test/fft_utest.cpp
+++ b/test/fft_utest.cpp
@@ -12,7 +12,7 @@ class FFTUtest {
         int i;
         for (i = 0; i < 100; i++) {
             T x = gf->weak_rand();
-            assert(1 == nttec::arith::_extended_gcd<T>(97, x, bezout, nullptr));
+            assert(1 == nttec::arith::extended_gcd<T>(97, x, bezout, nullptr));
             // std::cerr << bezout[0] << "*" << 97 << " " << bezout[1] << "*";
             // stdd:cerr << x << "=1\n";
             T y = gf->inv(x);
@@ -88,7 +88,7 @@ class FFTUtest {
 
         int b = 10; // base
         int p = 14; // we could multiply integers of 2^p digits
-        // int max_digits = nttec::arith::_exp<T>(2, p);
+        // int max_digits = nttec::arith::exp<T>(2, p);
         // std::cerr << "p=" << p << " max_digits=" << max_digits << "\n";
 
         uint64_t l = p + 1;
@@ -99,11 +99,11 @@ class FFTUtest {
         // a 2^n-th principal root of unity in GF_p
         uint64_t a1 = 2;
         uint64_t a2 = 5;
-        uint64_t p1 = a1 * nttec::arith::_exp<T>(2, 15) + 1;
-        uint64_t p2 = a2 * nttec::arith::_exp<T>(2, 15) + 1;
+        uint64_t p1 = a1 * nttec::arith::exp<T>(2, 15) + 1;
+        uint64_t p2 = a2 * nttec::arith::exp<T>(2, 15) + 1;
         // std::cerr << "p1=" << p1 << " p2=" << p2 << "\n";
-        assert(nttec::arith::_is_prime<T>(p1));
-        assert(nttec::arith::_is_prime<T>(p2));
+        assert(nttec::arith::is_prime<T>(p1));
+        assert(nttec::arith::is_prime<T>(p2));
 
         // ensure their product is bounded (b-1)^2*2^(n-1) < m
         uint64_t m = p1 * p2;
@@ -111,24 +111,21 @@ class FFTUtest {
         assert(m / p1 == p2);
         // std::cerr << " m=" << m << "\n";
         assert(
-            nttec::arith::_exp<T>((b - 1), 2) * nttec::arith::_exp<T>(p, 2)
-            < m);
+            nttec::arith::exp<T>((b - 1), 2) * nttec::arith::exp<T>(p, 2) < m);
 
         // find x so it is not a quadratic residue in GF_p1 and GF_p2
         assert(
-            nttec::arith::_jacobi<T>(3, p1) == nttec::arith::_jacobi<T>(p1, 3));
+            nttec::arith::jacobi<T>(3, p1) == nttec::arith::jacobi<T>(p1, 3));
+        assert(nttec::arith::jacobi<T>(p1, 3) == nttec::arith::jacobi<T>(2, 3));
         assert(
-            nttec::arith::_jacobi<T>(p1, 3) == nttec::arith::_jacobi<T>(2, 3));
-        assert(
-            nttec::arith::_jacobi<T>(3, p2) == nttec::arith::_jacobi<T>(p2, 3));
-        assert(
-            nttec::arith::_jacobi<T>(p2, 3) == nttec::arith::_jacobi<T>(2, 3));
-        assert(nttec::arith::_jacobi<T>(2, 3) == -1);
+            nttec::arith::jacobi<T>(3, p2) == nttec::arith::jacobi<T>(p2, 3));
+        assert(nttec::arith::jacobi<T>(p2, 3) == nttec::arith::jacobi<T>(2, 3));
+        assert(nttec::arith::jacobi<T>(2, 3) == -1);
         // which means x=3 is not a quadratic residue in GF_p1 and GF_p2
 
         // therefore we can compute 2^n-th roots of unity in GF_p1 and GF_p2
-        uint64_t w1 = nttec::arith::_exp<T>(3, a1);
-        uint64_t w2 = nttec::arith::_exp<T>(3, a2);
+        uint64_t w1 = nttec::arith::exp<T>(3, a1);
+        uint64_t w2 = nttec::arith::exp<T>(3, a2);
         // std::cerr << "w1=" << w1 << " w2=" << w2 << "\n";
         assert(w1 == 9);
         assert(w2 == 243);
@@ -140,7 +137,7 @@ class FFTUtest {
         _n[0] = p1;
         _a[1] = w2;
         _n[1] = p2;
-        uint64_t w = nttec::arith::_chinese_remainder<uint64_t>(2, _a, _n);
+        uint64_t w = nttec::arith::chinese_remainder<uint64_t>(2, _a, _n);
         // std::cerr << " w=" << w << "\n";
         assert(w == 25559439);
 
@@ -209,7 +206,7 @@ class FFTUtest {
 
         std::cout << "test_fftn\n";
 
-        assert(nttec::arith::_jacobi<T>(R, q) == -1);
+        assert(nttec::arith::jacobi<T>(R, q) == -1);
 
         // with this encoder we cannot exactly satisfy users request, we need to
         // pad n = minimal divisor of (q-1) that is at least (n_parities +
@@ -258,7 +255,7 @@ class FFTUtest {
 
         std::cout << "test_fft2k_vec\n";
 
-        assert(nttec::arith::_jacobi<T>(R, q) == -1);
+        assert(nttec::arith::jacobi<T>(R, q) == -1);
 
         // with this encoder we cannot exactly satisfy users request, we need to
         // pad n = minimal divisor of (q-1) that is at least (n_parities +
@@ -297,7 +294,7 @@ class FFTUtest {
 
         std::cout << "test_fft2k_vecp\n";
 
-        assert(nttec::arith::_jacobi<T>(R, q) == -1);
+        assert(nttec::arith::jacobi<T>(R, q) == -1);
 
         // with this encoder we cannot exactly satisfy users request, we need to
         // pad n = minimal divisor of (q-1) that is at least (n_parities +
@@ -515,8 +512,8 @@ class FFTUtest {
             nttec::gf::GF2N<T> gf(gf_n);
             std::cout << "test_fftadd_with_n=" << gf_n << "\n";
             // n is power of 2 and at least n_data + n_parities
-            n = nttec::arith::_get_smallest_power_of_2<T>(n_data + n_parities);
-            m = nttec::arith::_log2<T>(n);
+            n = nttec::arith::get_smallest_power_of_2<T>(n_data + n_parities);
+            m = nttec::arith::log2<T>(n);
 
             // std::cerr << "n=" << n << "\n";
             nttec::fft::FFTADD<T> fft(&gf, m);
@@ -570,7 +567,7 @@ class FFTUtest {
 
         std::cout << "test_fft2\n";
 
-        assert(nttec::arith::_jacobi<T>(R, q) == -1);
+        assert(nttec::arith::jacobi<T>(R, q) == -1);
 
         // with this encoder we cannot exactly satisfy users request, we need to
         // pad n = minimal divisor of (q-1) that is at least (n_parities +

--- a/test/gf_utest.cpp
+++ b/test/gf_utest.cpp
@@ -7,9 +7,9 @@ class GFUtest {
     {
         std::cout << "simple tests\n";
 
-        GFPN<T> gf256(
+        nttec::gf::GFPN<T> gf256(
             2, 8); // dumb way to declare a binary field but for sake of testing
-        Poly<T> _x(gf256.get_sub_field());
+        nttec::Poly<T> _x(gf256.get_sub_field());
         _x.set(6, 1);
         _x.set(4, 1);
         _x.set(1, 1);
@@ -26,8 +26,8 @@ class GFUtest {
         assert(_x.get(1) == 1);
         assert(_x.get(0) == 0);
 
-        GFPN<T> gf27(3, 3);
-        Poly<T> _y(gf27.get_sub_field());
+        nttec::gf::GFPN<T> gf27(3, 3);
+        nttec::Poly<T> _y(gf27.get_sub_field());
         _y.set(2, 1);
         _y.set(0, 1);
         T y = gf27.inv(_y.to_num());
@@ -38,7 +38,7 @@ class GFUtest {
         assert(_y.get(0) == 0);
     }
 
-    void test_negation(GF<T>* gf)
+    void test_negation(nttec::gf::GF<T>* gf)
     {
         int i;
 
@@ -55,7 +55,7 @@ class GFUtest {
         }
     }
 
-    void test_negation_ngff4(NGFF4<T>* gf)
+    void test_negation_ngff4(nttec::gf::NGFF4<T>* gf)
     {
         int i;
 
@@ -72,7 +72,7 @@ class GFUtest {
         }
     }
 
-    void test_reciprocal(GF<T>* gf)
+    void test_reciprocal(nttec::gf::GF<T>* gf)
     {
         int i;
         int n_found = 0;
@@ -86,7 +86,7 @@ class GFUtest {
             // std::cout << "x=" << x << "\n";
             try {
                 y = gf->inv(x);
-            } catch (NttecException e) {
+            } catch (nttec::NttecException e) {
                 continue;
             }
             // std::cout << "inv(x)=" << y << "\n";
@@ -96,7 +96,7 @@ class GFUtest {
         assert(n_found > 0);
     }
 
-    void test_reciprocal_ngff4(NGFF4<T>* gf)
+    void test_reciprocal_ngff4(nttec::gf::NGFF4<T>* gf)
     {
         int i;
         int n_found = 0;
@@ -110,7 +110,7 @@ class GFUtest {
             // std::cout << "x=" << x << "\n";
             try {
                 y = gf->inv(x);
-            } catch (NttecException e) {
+            } catch (nttec::NttecException e) {
                 continue;
             }
             // std::cout << "inv(x)=" << y << "\n";
@@ -120,7 +120,7 @@ class GFUtest {
         assert(n_found > 0);
     }
 
-    void test_log(GF<T>* gf)
+    void test_log(nttec::gf::GF<T>* gf)
     {
         int i;
         int n_found = 0;
@@ -149,13 +149,13 @@ class GFUtest {
         assert(n_found > 0);
     }
 
-    void test_pack_unpack(NGFF4<T>* gf)
+    void test_pack_unpack(nttec::gf::NGFF4<T>* gf)
     {
         int i;
 
         for (i = 0; i < 100; i++) {
             T x, y;
-            compT<T> z;
+            nttec::compT<T> z;
 
             // std::cout << "i=" << i << "\n";
 
@@ -169,14 +169,14 @@ class GFUtest {
         }
     }
 
-    void test_find_prime_root(GF<T>* gf)
+    void test_find_prime_root(nttec::gf::GF<T>* gf)
     {
         gf->find_prime_root();
         // std::cout << "root " << gf->root << std::endl;
         assert(gf->check_prime_root(gf->get_root()));
     }
 
-    void test_get_order(GF<T>* gf)
+    void test_get_order(nttec::gf::GF<T>* gf)
     {
         int i;
         T x;
@@ -192,7 +192,7 @@ class GFUtest {
         }
     }
 
-    void test_get_nth_root(GF<T>* gf)
+    void test_get_nth_root(nttec::gf::GF<T>* gf)
     {
         int i;
         T x;
@@ -211,7 +211,7 @@ class GFUtest {
     {
         std::cout << "test_negation_gf5\n";
 
-        GFP<T> gf5(5);
+        nttec::gf::GFP<T> gf5(5);
         test_negation(&gf5);
     }
 
@@ -219,7 +219,7 @@ class GFUtest {
     {
         std::cout << "test_reciprocal_gf5\n";
 
-        GFP<T> gf5(5);
+        nttec::gf::GFP<T> gf5(5);
         test_reciprocal(&gf5);
     }
 
@@ -227,7 +227,7 @@ class GFUtest {
     {
         std::cout << "test_log_gf5\n";
 
-        GFP<T> gf5(5);
+        nttec::gf::GFP<T> gf5(5);
         test_log(&gf5);
     }
 
@@ -235,7 +235,7 @@ class GFUtest {
     {
         std::cout << "test_prime_root_gf5\n";
 
-        GFP<T> gf5(5);
+        nttec::gf::GFP<T> gf5(5);
         test_find_prime_root(&gf5);
         test_get_order(&gf5);
         test_get_nth_root(&gf5);
@@ -245,7 +245,7 @@ class GFUtest {
     {
         std::cout << "test_negation_gf9\n";
 
-        GFPN<T> gf9(3, 2);
+        nttec::gf::GFPN<T> gf9(3, 2);
         test_negation(&gf9);
     }
 
@@ -253,7 +253,7 @@ class GFUtest {
     {
         std::cout << "test_reciprocal_gf9\n";
 
-        GFPN<T> gf9(3, 2);
+        nttec::gf::GFPN<T> gf9(3, 2);
         test_reciprocal(&gf9);
     }
 
@@ -261,7 +261,7 @@ class GFUtest {
     {
         std::cout << "test_log_gf9\n";
 
-        GFPN<T> gf9(3, 2);
+        nttec::gf::GFPN<T> gf9(3, 2);
         test_log(&gf9);
     }
 
@@ -269,7 +269,7 @@ class GFUtest {
     {
         std::cout << "test_prime_root_gf9\n";
 
-        GFPN<T> gf9(3, 2);
+        nttec::gf::GFPN<T> gf9(3, 2);
         test_find_prime_root(&gf9);
         test_get_order(&gf9);
         test_get_nth_root(&gf9);
@@ -279,7 +279,7 @@ class GFUtest {
     {
         std::cout << "test_negation_gf256\n";
 
-        GF2N<T> gf256(8);
+        nttec::gf::GF2N<T> gf256(8);
         test_negation(&gf256);
     }
 
@@ -287,7 +287,7 @@ class GFUtest {
     {
         std::cout << "test_reciprocal_gf256\n";
 
-        GF2N<T> gf256(8);
+        nttec::gf::GF2N<T> gf256(8);
         test_reciprocal(&gf256);
     }
 
@@ -295,7 +295,7 @@ class GFUtest {
     {
         std::cout << "test_log_gf256\n";
 
-        GF2N<T> gf256(8);
+        nttec::gf::GF2N<T> gf256(8);
         test_log(&gf256);
     }
 
@@ -303,7 +303,7 @@ class GFUtest {
     {
         std::cout << "test_prime_root_gf256\n";
 
-        GF2N<T> gf256(8);
+        nttec::gf::GF2N<T> gf256(8);
         test_find_prime_root(&gf256);
         test_get_order(&gf256);
         test_get_nth_root(&gf256);
@@ -313,7 +313,7 @@ class GFUtest {
     {
         std::cout << "test_negation_gf(2^" << n << ")\n";
 
-        GF2N<T> gf2n(n);
+        nttec::gf::GF2N<T> gf2n(n);
         test_negation(&gf2n);
     }
 
@@ -321,7 +321,7 @@ class GFUtest {
     {
         std::cout << "test_reciprocal_gf(2^" << n << ")\n";
 
-        GF2N<T> gf2n(n);
+        nttec::gf::GF2N<T> gf2n(n);
         test_reciprocal(&gf2n);
     }
 
@@ -329,7 +329,7 @@ class GFUtest {
     {
         std::cout << "test_log_gf(2^" << n << ")\n";
 
-        GF2N<T> gf2n(n);
+        nttec::gf::GF2N<T> gf2n(n);
         test_log(&gf2n);
     }
 
@@ -337,7 +337,7 @@ class GFUtest {
     {
         std::cout << "test_prime_root_gf(2^" << n << ")\n";
 
-        GF2N<T> gf2n(n);
+        nttec::gf::GF2N<T> gf2n(n);
         test_find_prime_root(&gf2n);
         test_get_order(&gf2n);
         test_get_nth_root(&gf2n);
@@ -349,7 +349,7 @@ class GFUtest {
 
         srand(time(0));
 
-        NGFF4<T> gf(n);
+        nttec::gf::NGFF4<T> gf(n);
 
         test_negation_ngff4(&gf);
         test_reciprocal_ngff4(&gf);
@@ -421,21 +421,6 @@ class GFUtest {
             gf_utest_2_bign(i);
     }
 };
-
-template class GF<uint32_t>;
-template class GFP<uint32_t>;
-template class GF2N<uint32_t>;
-template class NGFF4<uint32_t>;
-
-template class GF<uint64_t>;
-template class GFP<uint64_t>;
-template class GF2N<uint64_t>;
-template class NGFF4<uint64_t>;
-
-template class NGFF4<__uint128_t>;
-
-template class GF<mpz_class>;
-template class GFP<mpz_class>;
 
 void gf_utest()
 {

--- a/test/mat_utest.cpp
+++ b/test/mat_utest.cpp
@@ -1,17 +1,11 @@
 #include "nttec.h"
 
-template class GF<uint32_t>;
-template class GFP<uint32_t>;
-template class GF2N<uint32_t>;
-template class Mat<uint32_t>;
-template class Vec<uint32_t>;
-
 void mat_utest1()
 {
     std::cout << "mat_utest1\n";
 
-    GFP<uint32_t> gf11(11);
-    Mat<uint32_t> mat(&gf11, 3, 3);
+    nttec::gf::GFP<uint32_t> gf11(11);
+    nttec::Mat<uint32_t> mat(&gf11, 3, 3);
 
     mat.set(0, 0, 2);
     mat.set(0, 1, 1);
@@ -40,8 +34,8 @@ void mat_utest2()
 {
     std::cout << "mat_utest2\n";
 
-    GFP<uint32_t> gf29(29);
-    Mat<uint32_t> mat(&gf29, 3, 3);
+    nttec::gf::GFP<uint32_t> gf29(29);
+    nttec::Mat<uint32_t> mat(&gf29, 3, 3);
 
     mat.set(0, 0, 22);
     mat.set(0, 1, 27);

--- a/test/poly_utest.cpp
+++ b/test/poly_utest.cpp
@@ -1,16 +1,10 @@
 #include "nttec.h"
 
-template class GF<uint32_t>;
-template class GFP<uint32_t>;
-template class GF2N<uint32_t>;
-template class Mat<uint32_t>;
-template class Vec<uint32_t>;
-
 void poly_utest1()
 {
-    GFP<uint32_t> gfp(1000);
+    nttec::gf::GFP<uint32_t> gfp(1000);
 
-    Poly<uint32_t> p0(&gfp);
+    nttec::Poly<uint32_t> p0(&gfp);
     assert(0 == p0.degree());
 }
 
@@ -21,17 +15,17 @@ void poly_utest2()
 {
     std::cout << "poly_utest2\n";
 
-    GFP<uint32_t> gfp(11);
-    Poly<uint32_t> p1(&gfp);
+    nttec::gf::GFP<uint32_t> gfp(11);
+    nttec::Poly<uint32_t> p1(&gfp);
     p1.set(5, 1);
     p1.set(3, 3);
     p1.set(0, 4);
     // p1.dump();
-    Poly<uint32_t> p2(&gfp);
+    nttec::Poly<uint32_t> p2(&gfp);
     p2.set(6, 6);
     p2.set(3, 4);
     // p2.dump();
-    Poly<uint32_t> p3(&gfp);
+    nttec::Poly<uint32_t> p3(&gfp);
     p1._add(&p3, &p1, &p2);
     // p3.dump();
     assert(p3.degree() == 6);
@@ -45,17 +39,17 @@ void poly_utest3()
 {
     std::cout << "poly_utest3\n";
 
-    GFP<uint32_t> gfp(11);
-    Poly<uint32_t> p1(&gfp);
+    nttec::gf::GFP<uint32_t> gfp(11);
+    nttec::Poly<uint32_t> p1(&gfp);
     p1.set(5, 1);
     p1.set(3, 3);
     p1.set(0, 4);
     // p1.dump();
-    Poly<uint32_t> p2(&gfp);
+    nttec::Poly<uint32_t> p2(&gfp);
     p2.set(6, 6);
     p2.set(3, 4);
     // p2.dump();
-    Poly<uint32_t> p3(&gfp);
+    nttec::Poly<uint32_t> p3(&gfp);
     p1._sub(&p3, &p1, &p2);
     assert(p3.degree() == 6);
     assert(p3.get(6) == 5);
@@ -68,17 +62,17 @@ void poly_utest4()
 {
     std::cout << "poly_utest4\n";
 
-    GFP<uint32_t> gfp(11);
-    Poly<uint32_t> p1(&gfp);
+    nttec::gf::GFP<uint32_t> gfp(11);
+    nttec::Poly<uint32_t> p1(&gfp);
     p1.set(5, 1);
     p1.set(3, 3);
     p1.set(0, 4);
     // p1.dump();
-    Poly<uint32_t> p2(&gfp);
+    nttec::Poly<uint32_t> p2(&gfp);
     p2.set(6, 6);
     p2.set(3, 4);
     // p2.dump();
-    Poly<uint32_t> p3(&gfp);
+    nttec::Poly<uint32_t> p3(&gfp);
     p1._mul(&p3, &p1, &p2);
     assert(p3.degree() == 11);
     assert(p3.get(11) == 6);
@@ -91,20 +85,20 @@ void poly_utest4()
 void poly_utest5()
 {
     std::cout << "poly_utest5\n";
-    GFP<uint32_t> gfp(11);
-    Poly<uint32_t> p1(&gfp);
+    nttec::gf::GFP<uint32_t> gfp(11);
+    nttec::Poly<uint32_t> p1(&gfp);
     p1.set(6, 3);
     p1.set(4, 7);
     p1.set(3, 4);
     p1.set(0, 5);
     // p1.dump();
-    Poly<uint32_t> p2(&gfp);
+    nttec::Poly<uint32_t> p2(&gfp);
     p2.set(4, 1);
     p2.set(3, 3);
     p2.set(0, 4);
     // p2.dump();
-    Poly<uint32_t> p3(&gfp);
-    Poly<uint32_t> p4(&gfp);
+    nttec::Poly<uint32_t> p3(&gfp);
+    nttec::Poly<uint32_t> p4(&gfp);
     p1._div(&p3, &p4, &p1, &p2);
     // p3.dump();
     // p4.dump();
@@ -122,12 +116,12 @@ void poly_utest5()
 void poly_utest6()
 {
     std::cout << "poly_utest6\n";
-    GFP<uint32_t> gfp(11);
-    Poly<uint32_t> p1(&gfp);
+    nttec::gf::GFP<uint32_t> gfp(11);
+    nttec::Poly<uint32_t> p1(&gfp);
     p1.set(4, 4);
     p1.set(1, 1);
     p1.set(0, 8);
-    Poly<uint32_t> p2(&gfp);
+    nttec::Poly<uint32_t> p2(&gfp);
     p1._derivative(&p2, &p1);
     assert(p2.degree() == 3);
     assert(p2.get(3) == 5);
@@ -137,8 +131,8 @@ void poly_utest6()
 void poly_utest7()
 {
     std::cout << "poly_utest7\n";
-    GFP<uint32_t> gfp(11);
-    Poly<uint32_t> p1(&gfp);
+    nttec::gf::GFP<uint32_t> gfp(11);
+    nttec::Poly<uint32_t> p1(&gfp);
     p1.set(4, 4);
     p1.set(1, 1);
     p1.set(0, 8);
@@ -149,17 +143,17 @@ void poly_utest7()
 void poly_utest8()
 {
     std::cout << "poly_utest8\n";
-    GFP<uint32_t> gfp(3);
-    Poly<uint32_t> p1(&gfp);
+    nttec::gf::GFP<uint32_t> gfp(3);
+    nttec::Poly<uint32_t> p1(&gfp);
     p1.set(4, 1);
     // p1.dump();
-    Poly<uint32_t> p2(&gfp);
+    nttec::Poly<uint32_t> p2(&gfp);
     p2.set(3, 1);
     p2.set(2, 2);
     p2.set(0, 1);
     // p2.dump();
-    Poly<uint32_t> p3(&gfp);
-    Poly<uint32_t> p4(&gfp);
+    nttec::Poly<uint32_t> p3(&gfp);
+    nttec::Poly<uint32_t> p4(&gfp);
     p1._div(&p3, &p4, &p1, &p2);
     // p3.dump();
     // p4.dump();

--- a/test/rs_utest.cpp
+++ b/test/rs_utest.cpp
@@ -1,11 +1,5 @@
 #include "nttec.h"
 
-template class GF<uint32_t>;
-template class GFP<uint32_t>;
-template class GF2N<uint32_t>;
-template class Mat<uint32_t>;
-template class Vec<uint32_t>;
-
 /**
  * see http://web.eecs.utk.edu/~plank/plank/papers/CS-03-504.html
  */
@@ -13,8 +7,8 @@ void rs_utest1()
 {
     std::cout << "rs_utest1\n";
 
-    GF2N<uint32_t> gf16(4);
-    Mat<uint32_t> mat(&gf16, 3, 3);
+    nttec::gf::GF2N<uint32_t> gf16(4);
+    nttec::Mat<uint32_t> mat(&gf16, 3, 3);
 
     mat.vandermonde_suitable_for_ec();
     // mat.dump();
@@ -41,10 +35,10 @@ void rs_utest2()
 {
     std::cout << "rs_utest2\n";
 
-    GF2N<uint32_t> gf8(3);
-    Mat<uint32_t> mat(&gf8, 5, 3);
-    Vec<uint32_t> vec(&gf8, 3);
-    Vec<uint32_t> output(&gf8, 5);
+    nttec::gf::GF2N<uint32_t> gf8(3);
+    nttec::Mat<uint32_t> mat(&gf8, 5, 3);
+    nttec::vec::Vec<uint32_t> vec(&gf8, 3);
+    nttec::vec::Vec<uint32_t> output(&gf8, 5);
 
     mat.set(0, 0, 1);
     mat.set(0, 1, 1);
@@ -79,7 +73,7 @@ void rs_utest3()
 {
     std::cout << "rs_utest3\n";
 
-    GF2N<uint32_t> gf256(8);
+    nttec::gf::GF2N<uint32_t> gf256(8);
 
     assert(gf256.mul(3, 7) == 9);
     assert(gf256.mul(13, 10) == 114);

--- a/test/vec_utest.cpp
+++ b/test/vec_utest.cpp
@@ -7,10 +7,10 @@ class VECUtest {
     {
         std::cout << "vec_utest1\n";
 
-        GFP<T> gfp(65537);
-        Vec<T> vec1(&gfp, 16);
-        Vec<T> vec2(&gfp, 8);
-        V2Vec<T> v2vec2(&vec2);
+        nttec::gf::GFP<T> gfp(65537);
+        nttec::vec::Vec<T> vec1(&gfp, 16);
+        nttec::vec::Vec<T> vec2(&gfp, 8);
+        nttec::vec::V2Vec<T> v2vec2(&vec2);
 
         vec1.set(0, 1);
         vec1.set(1, 64);
@@ -62,10 +62,10 @@ class VECUtest {
     {
         std::cout << "vec_utest2\n";
 
-        GFP<T> gfp(65537);
-        Vec<T> vec1(&gfp, 8);
-        Vec<T> vec2(&gfp, 4);
-        V2Vec<T> v2vec2(&vec2);
+        nttec::gf::GFP<T> gfp(65537);
+        nttec::vec::Vec<T> vec1(&gfp, 8);
+        nttec::vec::Vec<T> vec2(&gfp, 4);
+        nttec::vec::V2Vec<T> v2vec2(&vec2);
 
         vec1.set(0, 5459);
         vec1.set(1, 11947);
@@ -97,9 +97,9 @@ class VECUtest {
     {
         std::cout << "vec_utest3\n";
 
-        GFP<T> gfp(65537);
+        nttec::gf::GFP<T> gfp(65537);
         int len = 20;
-        Vec<T> base_vec(&gfp, len);
+        nttec::vec::Vec<T> base_vec(&gfp, len);
         for (int i = 0; i < len; i++)
             base_vec.set(i, gfp.weak_rand());
         int len1 = 7;
@@ -110,11 +110,11 @@ class VECUtest {
         if (offset2 + len2 > len1)
             len3 = len1 - offset2;
         // vmvec1 = base_vec[offset1, .., offset1 + len1 - 1]
-        VmVec<T> vmvec1(&base_vec, len1, offset1);
+        nttec::vec::VmVec<T> vmvec1(&base_vec, len1, offset1);
         // vmvec2 = vmvec1[offset2, .., min(offset2 + len2 - 1, len1 - 1)]
-        VmVec<T> vmvec2(&vmvec1, len2, offset2);
+        nttec::vec::VmVec<T> vmvec2(&vmvec1, len2, offset2);
         // vmvec3 = base_vec[offset1 + offset2, .., offset1 + len1 - 1]
-        VmVec<T> vmvec3(&base_vec, len3, offset1 + offset2);
+        nttec::vec::VmVec<T> vmvec3(&base_vec, len3, offset1 + offset2);
         assert(vmvec3.eq(&vmvec2));
     }
 
@@ -127,16 +127,6 @@ class VECUtest {
         vec_utest3();
     }
 };
-
-template class GF<uint32_t>;
-template class GFP<uint32_t>;
-template class GF2N<uint32_t>;
-template class Vec<uint32_t>;
-
-template class GF<uint64_t>;
-template class GFP<uint64_t>;
-template class GF2N<uint64_t>;
-template class Vec<uint64_t>;
 
 void vec_utest()
 {

--- a/test/vecp_utest.cpp
+++ b/test/vecp_utest.cpp
@@ -157,8 +157,8 @@ class VECPUtest {
         int i;
         int word_size;
 
-        for (i = 0; i <= nttec::arith::_log2<T>(sizeof(T)); i++) {
-            word_size = nttec::arith::_exp2<T>(i);
+        for (i = 0; i <= nttec::arith::log2<T>(sizeof(T)); i++) {
+            word_size = nttec::arith::exp2<T>(i);
             pack_unpack(word_size);
         }
     }

--- a/test/vecp_utest.cpp
+++ b/test/vecp_utest.cpp
@@ -3,13 +3,13 @@
 template <typename T>
 class VECPUtest {
   private:
-    GFP<T>* gfp;
+    nttec::gf::GFP<T>* gfp;
     T max_val;
 
   public:
     VECPUtest()
     {
-        this->gfp = new GFP<T>(65537);
+        this->gfp = new nttec::gf::GFP<T>(65537);
         this->max_val = 65537;
     }
     ~VECPUtest()
@@ -17,10 +17,10 @@ class VECPUtest {
         delete this->gfp;
     }
 
-    Vecp<T>* gen_vecp_rand_data(int n, int size, int _max = 0)
+    nttec::vec::Vecp<T>* gen_vecp_rand_data(int n, int size, int _max = 0)
     {
         int max = (_max == 0) ? max_val : _max;
-        Vecp<T>* vec = new Vecp<T>(n, size);
+        nttec::vec::Vecp<T>* vec = new nttec::vec::Vecp<T>(n, size);
         for (int i = 0; i < n; i++) {
             T* buf = new T[size];
             for (int j = 0; j < size; j++) {
@@ -43,11 +43,11 @@ class VECPUtest {
         int size = 32;
         int i, j;
 
-        Vecp<T>* vec1 = gen_vecp_rand_data(n, size);
+        nttec::vec::Vecp<T>* vec1 = gen_vecp_rand_data(n, size);
         std::vector<T*>* mem1 = vec1->get_mem();
         // vec1->dump();
 
-        Vecp<T> vec2(vec1, begin, end);
+        nttec::vec::Vecp<T> vec2(vec1, begin, end);
         std::vector<T*>* mem2 = vec2.get_mem();
         assert(vec2.get_n() == end - begin);
         assert(vec2.get_size() == vec1->get_size());
@@ -62,7 +62,7 @@ class VECPUtest {
         for (int i = 0; i < end - begin; i++) {
             mem3[i] = mem1->at(i + begin);
         }
-        Vecp<T> vec3(end - begin, size, &mem3);
+        nttec::vec::Vecp<T> vec3(end - begin, size, &mem3);
         // vec3.dump();
 
         assert(vec2.eq(&vec3));
@@ -79,22 +79,24 @@ class VECPUtest {
         int i, j;
         int half = n / 2;
 
-        Vecp<T>* vec1 = gen_vecp_rand_data(n, size);
-        Vecp<T> vec2(n, size);
+        nttec::vec::Vecp<T>* vec1 = gen_vecp_rand_data(n, size);
+        nttec::vec::Vecp<T> vec2(n, size);
         vec2.copy(vec1);
 
         std::vector<T*>* even_mem = new std::vector<T*>(half, nullptr);
         std::vector<T*>* odd_mem = new std::vector<T*>(half, nullptr);
-        Vecp<T>* i_even = new Vecp<T>(half, size, even_mem);
-        Vecp<T>* i_odd = new Vecp<T>(half, size, odd_mem);
+        nttec::vec::Vecp<T>* i_even =
+            new nttec::vec::Vecp<T>(half, size, even_mem);
+        nttec::vec::Vecp<T>* i_odd =
+            new nttec::vec::Vecp<T>(half, size, odd_mem);
         vec1->separate_even_odd(i_even, i_odd);
 
         // vec1->dump();
         vec1->separate_even_odd();
         // vec1->dump();
 
-        Vecp<T> _i_even(vec1, 0, half);
-        Vecp<T> _i_odd(vec1, half, n);
+        nttec::vec::Vecp<T> _i_even(vec1, 0, half);
+        nttec::vec::Vecp<T> _i_odd(vec1, half, n);
         assert(i_even->eq(&_i_even));
         assert(i_odd->eq(&_i_odd));
 
@@ -131,19 +133,19 @@ class VECPUtest {
         int n1 = 4;
         int n2 = 10;
 
-        Vecp<T>* vec = gen_vecp_rand_data(n, size);
-        Vecp<T> vec1(vec, n1);
-        Vecp<T> vec2(vec, n2);
+        nttec::vec::Vecp<T>* vec = gen_vecp_rand_data(n, size);
+        nttec::vec::Vecp<T> vec1(vec, n1);
+        nttec::vec::Vecp<T> vec2(vec, n2);
 
-        Vecp<T> _vec1(vec, 0, n1);
-        Vecp<T>* _vec2 = new VVecp<T>(vec, n2);
+        nttec::vec::Vecp<T> _vec1(vec, 0, n1);
+        nttec::vec::Vecp<T>* _vec2 = new nttec::vec::VVecp<T>(vec, n2);
 
         assert(vec1.eq(&_vec1));
         assert(vec2.eq(_vec2));
 
         delete vec;
 
-        Vecp<T> vec3(&vec2, n1);
+        nttec::vec::Vecp<T> vec3(&vec2, n1);
         assert(vec3.eq(&vec1));
 
         delete _vec2;
@@ -155,8 +157,8 @@ class VECPUtest {
         int i;
         int word_size;
 
-        for (i = 0; i <= _log2<T>(sizeof(T)); i++) {
-            word_size = _exp2<T>(i);
+        for (i = 0; i <= nttec::arith::_log2<T>(sizeof(T)); i++) {
+            word_size = nttec::arith::_exp2<T>(i);
             pack_unpack(word_size);
         }
     }
@@ -172,12 +174,12 @@ class VECPUtest {
         T symb;
         T max = ((T)1 << word_size) + 1;
 
-        Vecp<T>* words = gen_vecp_rand_data(n, size, max);
+        nttec::vec::Vecp<T>* words = gen_vecp_rand_data(n, size, max);
         std::vector<T*>* mem_T = words->get_mem();
         // std::cout << "words:"; words->dump();
 
         // pack manually from T to uint8_t
-        Vecp<uint8_t> vec_char(n, bytes_size);
+        nttec::vec::Vecp<uint8_t> vec_char(n, bytes_size);
         std::vector<uint8_t*>* mem_char = vec_char.get_mem();
         for (i = 0; i < n; i++) {
             t = 0;
@@ -199,9 +201,9 @@ class VECPUtest {
          * pack bufs of type uint8_t to bufs of type T
          */
         // tmp vectors to store results
-        Vecp<T> vec_T_tmp(n, size);
+        nttec::vec::Vecp<T> vec_T_tmp(n, size);
         std::vector<T*>* mem_T_tmp = vec_T_tmp.get_mem();
-        pack<uint8_t, T>(mem_char, mem_T_tmp, n, size, word_size);
+        nttec::vec::pack<uint8_t, T>(mem_char, mem_T_tmp, n, size, word_size);
         // std::cout << "vec_char:"; vec_char.dump();
         // std::cout << "vec_T_tmp:"; vec_T_tmp.dump();
         // check
@@ -211,9 +213,10 @@ class VECPUtest {
          * unpack bufs of type T to bufs of type uint8_t
          */
         // tmp vectors to store results
-        Vecp<uint8_t> vec_char_tmp(n, bytes_size);
+        nttec::vec::Vecp<uint8_t> vec_char_tmp(n, bytes_size);
         std::vector<uint8_t*>* mem_char_tmp = vec_char_tmp.get_mem();
-        unpack<T, uint8_t>(mem_T_tmp, mem_char_tmp, n, size, word_size);
+        nttec::vec::unpack<T, uint8_t>(
+            mem_T_tmp, mem_char_tmp, n, size, word_size);
         // std::cout << "vec_T_tmp:"; vec_T_tmp.dump();
         // std::cout << "vec_char_tmp:"; vec_char_tmp.dump();
         // check
@@ -232,16 +235,6 @@ class VECPUtest {
         vecp_utest4();
     }
 };
-
-template class GF<uint32_t>;
-template class GFP<uint32_t>;
-template class GF2N<uint32_t>;
-template class Vec<uint32_t>;
-
-template class GF<uint64_t>;
-template class GFP<uint64_t>;
-template class GF2N<uint64_t>;
-template class Vec<uint64_t>;
 
 void vecp_utest()
 {

--- a/tools/ec.cpp
+++ b/tools/ec.cpp
@@ -1,26 +1,9 @@
-
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include "nttec.h"
 
-template class GF<uint32_t>;
-template class GFP<uint32_t>;
-template class GF2N<uint32_t>;
-template class GF2N<uint64_t>;
-template class Mat<uint32_t>;
-template class Vec<uint32_t>;
-template class FEC<uint32_t>;
-template class FECGF2NRS<uint32_t>;
-template class FECGF2NRS<uint64_t>;
-template class FECFNTRS<uint32_t>;
-template class FECGF2NFFTRS<uint32_t>;
-template class FECGF2NFFTRS<uint64_t>;
-template class FECGF2NFFTADDRS<uint32_t>;
-template class FECGF2NFFTADDRS<uint64_t>;
-template class FECGF2NFFTADDRS<__uint128_t>;
-template class FECGFPFFTRS<uint64_t>;
+#include "nttec.h"
 
 int vflag = 0;
 int tflag = 0;
@@ -55,13 +38,15 @@ char* xstrdup(const char* str)
  *
  */
 template <typename T>
-void create_coding_files(FEC<T>* fec, bool operation_on_packet = false)
+void create_coding_files(
+    nttec::fec::FEC<T>* fec,
+    bool operation_on_packet = false)
 {
     char filename[1024];
     std::vector<std::istream*> d_files(fec->n_data, nullptr);
     std::vector<std::ostream*> c_files(fec->n_outputs, nullptr);
     std::vector<std::ostream*> c_props_files(fec->n_outputs, nullptr);
-    std::vector<KeyValue*> c_props(fec->n_outputs, nullptr);
+    std::vector<nttec::KeyValue*> c_props(fec->n_outputs, nullptr);
 
     for (unsigned i = 0; i < fec->n_data; i++) {
         snprintf(filename, sizeof(filename), "%s.d%d", prefix, i);
@@ -81,7 +66,7 @@ void create_coding_files(FEC<T>* fec, bool operation_on_packet = false)
             std::cerr << "create: opening coding props for writing " << filename
                       << "\n";
         c_props_files[i] = new std::ofstream(filename);
-        c_props[i] = new KeyValue();
+        c_props[i] = new nttec::KeyValue();
     }
 
     if (operation_on_packet)
@@ -111,13 +96,13 @@ void create_coding_files(FEC<T>* fec, bool operation_on_packet = false)
  *
  */
 template <typename T>
-bool repair_data_files(FEC<T>* fec)
+bool repair_data_files(nttec::fec::FEC<T>* fec)
 {
     char filename[1024];
     std::vector<std::istream*> d_files(fec->n_data, nullptr);
     std::vector<std::istream*> c_files(fec->n_outputs, nullptr);
     std::vector<std::istream*> c_props_files(fec->n_outputs, nullptr);
-    std::vector<KeyValue*> c_props(fec->n_outputs, nullptr);
+    std::vector<nttec::KeyValue*> c_props(fec->n_outputs, nullptr);
     std::vector<std::ostream*> r_files(fec->n_data, nullptr);
 
     // re-read data
@@ -156,7 +141,7 @@ bool repair_data_files(FEC<T>* fec)
             c_props[i] = nullptr;
         } else {
             c_props_files[i] = new std::ifstream(filename);
-            c_props[i] = new KeyValue();
+            c_props[i] = new nttec::KeyValue();
             *(c_props_files[i]) >> *(c_props[i]);
         }
     }
@@ -196,7 +181,7 @@ bool repair_data_files(FEC<T>* fec)
 }
 
 template <typename T>
-void print_stats(FEC<T>* fec)
+void print_stats(nttec::fec::FEC<T>* fec)
 {
     std::cerr << "enc,"
               << (fec->n_encode_ops != 0
@@ -211,13 +196,13 @@ void print_stats(FEC<T>* fec)
 }
 
 template <typename T>
-void print_fec_type(FEC<T>* fec)
+void print_fec_type(nttec::fec::FEC<T>* fec)
 {
     switch (fec->type) {
-    case FEC<T>::TYPE_1:
+    case nttec::fec::FEC<T>::TYPE_1:
         std::cout << "type_1\n";
         break;
-    case FEC<T>::TYPE_2:
+    case nttec::fec::FEC<T>::TYPE_2:
         std::cout << "type_2\n";
         break;
     default:
@@ -239,14 +224,15 @@ void run_FECGF2NRS(
     gf2nrs_type mflag,
     int rflag)
 {
-    FECGF2NRS<T>* fec;
-    typename FECGF2NRS<T>::FECGF2NRSType gf2nrs_type;
+    nttec::fec::FECGF2NRS<T>* fec;
+    typename nttec::fec::FECGF2NRS<T>::FECGF2NRSType gf2nrs_type;
     ;
     if (mflag == VANDERMONDE)
-        gf2nrs_type = FECGF2NRS<T>::VANDERMONDE;
+        gf2nrs_type = nttec::fec::FECGF2NRS<T>::VANDERMONDE;
     else
-        gf2nrs_type = FECGF2NRS<T>::CAUCHY;
-    fec = new FECGF2NRS<T>(word_size, n_data, n_parities, gf2nrs_type);
+        gf2nrs_type = nttec::fec::FECGF2NRS<T>::CAUCHY;
+    fec = new nttec::fec::FECGF2NRS<T>(
+        word_size, n_data, n_parities, gf2nrs_type);
 
     if (tflag) {
         print_fec_type<T>(fec);
@@ -265,8 +251,8 @@ void run_FECGF2NRS(
 template <typename T>
 void run_FECGF2NFFTRS(int word_size, int n_data, int n_parities, int rflag)
 {
-    FECGF2NFFTRS<T>* fec;
-    fec = new FECGF2NFFTRS<T>(word_size, n_data, n_parities);
+    nttec::fec::FECGF2NFFTRS<T>* fec;
+    fec = new nttec::fec::FECGF2NFFTRS<T>(word_size, n_data, n_parities);
 
     if (tflag) {
         print_fec_type<T>(fec);
@@ -285,8 +271,8 @@ void run_FECGF2NFFTRS(int word_size, int n_data, int n_parities, int rflag)
 template <typename T>
 void run_FECGF2NFFTADDRS(int word_size, int n_data, int n_parities, int rflag)
 {
-    FECGF2NFFTADDRS<T>* fec;
-    fec = new FECGF2NFFTADDRS<T>(word_size, n_data, n_parities);
+    nttec::fec::FECGF2NFFTADDRS<T>* fec;
+    fec = new nttec::fec::FECGF2NFFTADDRS<T>(word_size, n_data, n_parities);
 
     if (tflag) {
         print_fec_type<T>(fec);
@@ -307,8 +293,8 @@ void run_FECGFPFFTRS(unsigned word_size, int n_data, int n_parities, int rflag)
 {
     assert(sizeof(T) > word_size);
 
-    FECGFPFFTRS<T>* fec;
-    fec = new FECGFPFFTRS<T>(word_size, n_data, n_parities);
+    nttec::fec::FECGFPFFTRS<T>* fec;
+    fec = new nttec::fec::FECGFPFFTRS<T>(word_size, n_data, n_parities);
 
     if (tflag) {
         print_fec_type<T>(fec);
@@ -327,9 +313,9 @@ void run_FECGFPFFTRS(unsigned word_size, int n_data, int n_parities, int rflag)
 template <typename T>
 void run_FECFNTRS(int word_size, int n_data, int n_parities, int rflag)
 {
-    FECFNTRS<T>* fec;
+    nttec::fec::FECFNTRS<T>* fec;
     size_t pkt_size = 1024;
-    fec = new FECFNTRS<T>(word_size, n_data, n_parities, pkt_size);
+    fec = new nttec::fec::FECFNTRS<T>(word_size, n_data, n_parities, pkt_size);
 
     if (tflag) {
         print_fec_type<T>(fec);
@@ -348,8 +334,8 @@ void run_FECFNTRS(int word_size, int n_data, int n_parities, int rflag)
 template <typename T>
 void run_FECNGFF4RS(int word_size, int n_data, int n_parities, int rflag)
 {
-    FECNGFF4RS<T>* fec;
-    fec = new FECNGFF4RS<T>(word_size, n_data, n_parities);
+    nttec::fec::FECNGFF4RS<T>* fec;
+    fec = new nttec::fec::FECNGFF4RS<T>(word_size, n_data, n_parities);
 
     if (tflag) {
         print_fec_type<T>(fec);

--- a/tools/is_prime.cpp
+++ b/tools/is_prime.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv)
     exit(1);
   }
 
-  bool result = gfp._is_prime(n);
+  bool result = gfp.is_prime(n);
   std::cerr << result << "\n";
   exit(result == true ? 0 : 1);
 }


### PR DESCRIPTION
We introduce the following namespaces:
- nttec: the root namespace of the NTTEC library
- nttec::arith: for the base/core arithmetical functions of NTTEC.
- nttec::fec: for the code related to Forward Error Correction.
- nttec::gf: for the code related to Galois Fields.
- nttec::fft: for the code related to the Fast Fourier Transform.
- nttec::vec: for the low-level wrappers around memory buffer.

Note that we add to move the overloading of << for the 128-bit integers
into the namespace "std", otherwise we have some problem to find it when
needed (ADL cannot find it in some cases).

Also move pack/unpack helper of Vec from `fec.h` to `vec.h`: it's more
logical that way.

Closes: #155