### PR TITLE
export the version string

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Source files.
 set(LIB_SRC
+  ${SOURCE_DIR}/core.cpp
   ${SOURCE_DIR}/misc.cpp
   ${SOURCE_DIR}/property.cpp
   ${SOURCE_DIR}/vec.cpp

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1,0 +1,11 @@
+#include "build_info.h"
+#include "core.h"
+
+namespace nttec {
+
+const char* get_version()
+{
+    return VERSION;
+}
+
+} // namespace nttec

--- a/src/core.h
+++ b/src/core.h
@@ -64,6 +64,15 @@ typedef enum {
     NTTEC_EX_DIV_BY_ZERO,
 } NttecException;
 
+/** Return the version string of NTTEC.
+ *
+ * The version string has the form MAJOR.MINOR.PATCH-REVISION, where '-REVISION'
+ * is optional (only present for development version).
+ *
+ * @return the version string.
+ */
+const char* get_version();
+
 } // namespace nttec
 
 #endif

--- a/src/nttec.h
+++ b/src/nttec.h
@@ -8,7 +8,6 @@
  */
 
 #include "arith.h"
-#include "build_info.h"
 #include "core.h"
 #include "dft.h"
 #include "dftn.h"


### PR DESCRIPTION
I'll use this function to test the inclusion of NTTEC in QuadIron's build system.