### PR TITLE
Ft: fft2k faster

### DIFF
--- a/src/dft.h
+++ b/src/dft.h
@@ -30,6 +30,9 @@ class DFT {
     virtual void fft(vec::Vec<T>* output, vec::Vec<T>* input) = 0;
     virtual void ifft(vec::Vec<T>* output, vec::Vec<T>* input) = 0;
     virtual void fft_inv(vec::Vec<T>* output, vec::Vec<T>* input) = 0;
+    virtual void fft(vec::Vecp<T>* output, vec::Vecp<T>* input){};
+    virtual void ifft(vec::Vecp<T>* output, vec::Vecp<T>* input){};
+    virtual void fft_inv(vec::Vecp<T>* output, vec::Vecp<T>* input){};
 };
 
 template <typename T>

--- a/src/fecfntrs.h
+++ b/src/fecfntrs.h
@@ -52,7 +52,8 @@ class FECFNTRS : public FEC<T> {
         // std::cerr << "n=" << n << "\n";
         // std::cerr << "r=" << r << "\n";
 
-        this->fft = new fft::FFT2K<T>(this->gf, n, pkt_size);
+        int m = arith::get_smallest_power_of_2<int>(n_data);
+        this->fft = new fft::FFT2K<T>(this->gf, n, m, pkt_size);
     }
 
     ~FECFNTRS()

--- a/src/fft1.h
+++ b/src/fft1.h
@@ -1,0 +1,92 @@
+/* -*- mode: c++ -*- */
+#ifndef __NTTEC_FFT1_H__
+#define __NTTEC_FFT1_H__
+
+#include "dft.h"
+#include "vec.h"
+
+namespace nttec {
+namespace fft {
+
+/**
+ * Algorithm for FFT(n) where input's elements except the first one are all zero
+ * All elements of output equals the first element of input
+ */
+template <typename T>
+class FFT1 : public DFT<T> {
+  public:
+    explicit FFT1(gf::GF<T>* gf, int n);
+    ~FFT1();
+    void fft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void ifft(vec::Vec<T>* output, vec::Vec<T>* input);
+    void fft_inv(vec::Vec<T>* output, vec::Vec<T>* input);
+    void fft(vec::Vecp<T>* output, vec::Vecp<T>* input);
+    void ifft(vec::Vecp<T>* output, vec::Vecp<T>* input);
+    void fft_inv(vec::Vecp<T>* output, vec::Vecp<T>* input);
+};
+
+template <typename T>
+FFT1<T>::FFT1(gf::GF<T>* gf, int n) : DFT<T>(gf, n)
+{
+}
+
+template <typename T>
+FFT1<T>::~FFT1()
+{
+}
+
+template <typename T>
+void FFT1<T>::fft(vec::Vec<T>* output, vec::Vec<T>* input)
+{
+    T val = input->get(0);
+    output->fill(val);
+}
+
+/*
+ * This function performs an inverse DFT formular without a multiplication to
+ * the coefficient (n^(-1) mod p)
+ *
+ */
+template <typename T>
+void FFT1<T>::fft_inv(vec::Vec<T>* output, vec::Vec<T>* input)
+{
+    fft(output, input);
+}
+
+template <typename T>
+void FFT1<T>::ifft(vec::Vec<T>* output, vec::Vec<T>* input)
+{
+    output->zero_fill();
+    output->set(0, input->get(0));
+}
+
+template <typename T>
+void FFT1<T>::fft(vec::Vecp<T>* output, vec::Vecp<T>* input)
+{
+    T* buf = input->get(0);
+    for (int i = 0; i < this->n; i++)
+        output->copy(i, buf);
+}
+
+/*
+ * This function performs an inverse DFT formular without a multiplication to
+ * the coefficient (n^(-1) mod p)
+ *
+ */
+template <typename T>
+void FFT1<T>::fft_inv(vec::Vecp<T>* output, vec::Vecp<T>* input)
+{
+    fft(output, input);
+}
+
+template <typename T>
+void FFT1<T>::ifft(vec::Vecp<T>* output, vec::Vecp<T>* input)
+{
+    output->zero_fill();
+    output->copy(0, input->get(0));
+}
+
+} // namespace fft
+} // namespace nttec
+
+#endif

--- a/src/nttec.h
+++ b/src/nttec.h
@@ -18,6 +18,7 @@
 #include "fecgf2nrs.h"
 #include "fecgfpfftrs.h"
 #include "fecngff4.h"
+#include "fft1.h"
 #include "fft2.h"
 #include "fft2k.h"
 #include "fftadd.h"

--- a/src/vec.h
+++ b/src/vec.h
@@ -143,6 +143,7 @@ class Vec {
     virtual int get_n(void);
     int get_mem_len(void);
     void zero_fill(void);
+    void fill(T val);
     virtual void set(int i, T val);
     virtual T get(int i);
     T* get_mem();
@@ -209,6 +210,15 @@ void Vec<T>::zero_fill(void)
 
     for (i = 0; i < n; i++)
         set(i, 0);
+}
+
+template <typename T>
+void Vec<T>::fill(T val)
+{
+    int i;
+
+    for (i = 0; i < n; i++)
+        mem[i] = val;
 }
 
 template <typename T>

--- a/src/vecp.h
+++ b/src/vecp.h
@@ -48,6 +48,7 @@ class Vecp {
     std::vector<T*>* get_mem();
     void set_mem(std::vector<T*>* mem);
     void copy(Vecp<T>* v);
+    void copy(int i, T* buf);
     void separate_even_odd();
     void separate_even_odd(Vecp<T>* even, Vecp<T>* odd);
     bool eq(Vecp<T>* v);
@@ -213,6 +214,12 @@ void Vecp<T>::copy(Vecp<T>* v)
     size_t v_size = v->get_size();
     for (int i = 0; i < n; i++)
         std::copy_n(v->get(i), v_size, this->mem->at(i));
+}
+
+template <typename T>
+void Vecp<T>::copy(int i, T* buf)
+{
+    std::copy_n(buf, this->size, this->mem->at(i));
 }
 
 template <typename T>

--- a/test/fft_utest.cpp
+++ b/test/fft_utest.cpp
@@ -555,6 +555,30 @@ class FFTUtest {
         }
     }
 
+    void test_fft1_gfp()
+    {
+        nttec::gf::GFP<T> gf(39);
+
+        std::cout << "test_fft1_gfp\n";
+
+        int n = 16;
+        nttec::fft::FFT1<T> fft(&gf, n);
+
+        nttec::vec::Vec<T> v(&gf, fft.get_n());
+        nttec::vec::Vec<T> _v(&gf, fft.get_n());
+        nttec::vec::Vec<T> v2(&gf, fft.get_n());
+        for (int j = 0; j < 100000; j++) {
+            v.zero_fill();
+            v.set(0, gf.weak_rand());
+            // v.dump();
+            fft.fft(&_v, &v);
+            // _v.dump();
+            fft.ifft(&v2, &_v);
+            // v2.dump();
+            assert(v.eq(&v2));
+        }
+    }
+
     void test_fft2()
     {
         unsigned n;
@@ -674,6 +698,7 @@ class FFTUtest {
         test_fftadd();
         test_fft2();
         test_fft2_gfp();
+        test_fft1_gfp();
         test_fft_gf2n();
         test_mul_bignum();
     }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -16,7 +16,7 @@ struct test {
 } tests[] = {{"arith", arith_utest},
              {"gf", gf_utest},
              {"vec", vec_utest},
-             {"vecp", vec_utest},
+             {"vecp", vecp_utest},
              {"mat", mat_utest},
              {"rs", rs_utest},
              {"poly", poly_utest},


### PR DESCRIPTION
# FFT1: special case of DFT

Input's elements except the first one are all zero.
Hence, all elements of output equals the first element of input

#  FFT2K has now two trivial cases
- All elements of input, except the first element, are all zeros
- FFT length is 2

# FNTRS: use new FFT2K
Thanks to FFT1, encoding has complexity `O(N logK)` instead of `O(N logN)`