### PR TITLE
remove is_v2vec

### DIFF
--- a/src/vec_doubled.h
+++ b/src/vec_doubled.h
@@ -29,17 +29,10 @@ class Doubled : public Vector<T> {
     explicit Doubled(Vector<T>* vec);
     int get_n(void);
     T get(int i);
-    bool is_v2vec();
 
   private:
     Vector<T>* vec;
 };
-
-template <typename T>
-bool Doubled<T>::is_v2vec()
-{
-    return true;
-}
 
 template <typename T>
 Doubled<T>::Doubled(Vector<T>* vec)

--- a/src/vec_vector.h
+++ b/src/vec_vector.h
@@ -143,7 +143,6 @@ class Vector {
     virtual T get(int i);
     T* get_mem();
     void set_mem(T* mem, int mem_len);
-    virtual bool is_v2vec();
     void mul_scalar(T scalar);
     void mul_beta(T beta);
     void hadamard_mul(Vector<T>* v);
@@ -253,12 +252,6 @@ inline void Vector<T>::set_mem(T* mem, int mem_len)
     new_mem = false;
     this->mem = mem;
     this->mem_len = mem_len;
-}
-
-template <typename T>
-bool Vector<T>::is_v2vec()
-{
-    return false;
 }
 
 /**


### PR DESCRIPTION
This function is never used.

Closes: #181